### PR TITLE
docs: Fix help command line parameter

### DIFF
--- a/gtfs-realtime-validator-lib/src/main/java/edu/usf/cutr/gtfsrtvalidator/lib/Main.java
+++ b/gtfs-realtime-validator-lib/src/main/java/edu/usf/cutr/gtfsrtvalidator/lib/Main.java
@@ -46,7 +46,7 @@ public class Main {
         String gtfs = getGtfsPathAndFileFromArgs(options, args);
         String gtfsRealtime = getGtfsRealtimePath(options, args);
         if (gtfs == null || gtfsRealtime == null) {
-            throw new IllegalArgumentException("For batch mode you must provide a path and file name to GTFS data (e.g., -gtfs /dir/gtfs.zip) and path to directory of all archived GTFS-rt files (e.g., -gtfs-realtime-path /dir/gtfsarchive)");
+            throw new IllegalArgumentException("For batch mode you must provide a path and file name to GTFS data (e.g., -gtfs /dir/gtfs.zip) and path to directory of all archived GTFS-rt files (e.g., -gtfsRealtimePath /dir/gtfsarchive)");
         }
         BatchProcessor.SortBy sortBy = getSortBy(options, args);
         String plainText = getPlainTextFileExtensionfromArgs(options, args);


### PR DESCRIPTION
**Summary:**

With this change it now matches https://github.com/MobilityData/gtfs-realtime-validator/tree/master/gtfs-realtime-validator-lib#run-it-yourself (i.e., it should be in camelCase).

**Expected behavior:** 

Command line parameters in the help output should match the actual command line parameters.

Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] Run the unit tests with `mvn test` to make sure you didn't break anything
- [ ] Format the title like "Fix #<issue_number> - <short description of fix and changes>" (for example - "Fix #1111 - Check for null value before using field")
- [ ] Linked all relevant issues
- [ ] Include screenshot(s) showing how this pull request works and fixes the issue(s)
