### PR TITLE
docs: Update PR template for Conventional Commits

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -10,6 +10,6 @@ Explain and/or show screenshots for how you expect the pull request to work in y
 Please make sure these boxes are checked before submitting your pull request - thanks!
 
 - [ ] Run the unit tests with `mvn test` to make sure you didn't break anything
-- [ ] Format the title like "Fix #<issue_number> - <short description of fix and changes>" (for example - "Fix #1111 - Check for null value before using field")
+- [ ] Format the title like "feat: {new feature short description}" or "fix: {describe what was fixed}". Title must follow the Conventional Commit Specification (https://www.conventionalcommits.org/en/v1.0.0/).
 - [ ] Linked all relevant issues
 - [ ] Include screenshot(s) showing how this pull request works and fixes the issue(s)


### PR DESCRIPTION
**Summary:**

We're using Conventional Commit Specification (https://www.conventionalcommits.org/en/v1.0.0/) for commit title formatting, but the PR template docs reflect the old format.

This change updates the template to specify Conventional Commits in the PR template.

**Expected behavior:** 

PR template should reflect the correct formatting guidelines, using Conventional Commit Specification (https://www.conventionalcommits.org/en/v1.0.0/).

Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] Run the unit tests with `mvn test` to make sure you didn't break anything
~~- [ ] Format the title like "Fix #<issue_number> - <short description of fix and changes>" (for example - "Fix #1111 - Check for null value before using field")~~
- [ ] Linked all relevant issues
- [ ] Include screenshot(s) showing how this pull request works and fixes the issue(s)
