### PR TITLE
feat: Link the "Help" and "Contact Us" buttons on index webpage

### DIFF
--- a/gtfs-realtime-validator-webapp/src/main/resources/webroot/index.html
+++ b/gtfs-realtime-validator-webapp/src/main/resources/webroot/index.html
@@ -24,9 +24,8 @@
         </div>
         <div class="collapse navbar-collapse">
             <ul class="nav navbar-nav pull-right">
-                <li><a href="#">About</a></li>
-                <li><a href="#">Help</a></li>
-                <li><a href="#">Contact Us</a></li>
+                <li><a href="https://github.com/MobilityData/gtfs-realtime-validator/blob/master/TROUBLESHOOTING.md">Help</a></li>
+                <li><a href="https://bit.ly/mobilitydata-slack">Contact Us</a></li>
             </ul>
         </div>
         <!--/.nav-collapse -->


### PR DESCRIPTION
**Summary:**

This PR adds hyperlinks to the "Help" and "Contact Us" buttons in the top bar of the index website:

![image](https://user-images.githubusercontent.com/928045/155809558-60919cf4-581f-466e-bc18-0afe08cb7958.png)

Right now here are the hyperlinks, although these can be changed:
* Help -> https://github.com/MobilityData/gtfs-realtime-validator/blob/master/TROUBLESHOOTING.md
* Contact Us -> https://bit.ly/mobilitydata-slack

This PR also removes the "About" menu item, as that is ticketed separately in https://github.com/MobilityData/gtfs-realtime-validator/issues/52 with some work towards it in https://github.com/MobilityData/gtfs-realtime-validator/pull/84.

Closes https://github.com/MobilityData/gtfs-realtime-validator/issues/50.

**Expected behavior:** 

Currently when clicking "Help" and "Contact Us" nothing happens. This PR adds hyperlinks to both.

Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] Run the unit tests with `mvn test` to make sure you didn't break anything
- [x] Format the title like "feat: {new feature short description}" or "fix: {describe what was fixed}". Title must follow the Conventional Commit Specification (https://www.conventionalcommits.org/en/v1.0.0/).
- [x] Linked all relevant issues
- [x] Include screenshot(s) showing how this pull request works and fixes the issue(s)
