### PR TITLE
fix: Bump frontend-maven-plugin for Mac M1 builds

### DIFF
--- a/gtfs-realtime-validator-webapp/pom.xml
+++ b/gtfs-realtime-validator-webapp/pom.xml
@@ -257,7 +257,7 @@
             <plugin>
                 <groupId>com.github.eirslett</groupId>
                 <artifactId>frontend-maven-plugin</artifactId>
-                <version>1.4</version>
+                <version>1.12.1</version>
 
                 <executions>
                     <execution>


### PR DESCRIPTION
**Summary:**

As mentioned by @lionel-nj in https://github.com/MobilityData/gtfs-realtime-validator/issues/101, builds currently fail on an Apple Mac M1 due to an issue with the `frontend-maven-plugin` dependency - see https://github.com/eirslett/frontend-maven-plugin/issues/952#issuecomment-762163294.

As suggested in https://github.com/MobilityData/gtfs-realtime-validator/issues/101, this bumps the version of `frontend-maven-plugin` so it should build on Mac M1s now.

Closes https://github.com/MobilityData/gtfs-realtime-validator/issues/101.

**Expected behavior:** 

Build on Mac M1s (and all other platforms).

Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] Run the unit tests with `mvn test` to make sure you didn't break anything
- [x] Format the title like "feat: {new feature short description}" or "fix: {describe what was fixed}". Title must follow the Conventional Commit Specification (https://www.conventionalcommits.org/en/v1.0.0/).
- [x] Linked all relevant issues
- [x] Include screenshot(s) showing how this pull request works and fixes the issue(s)
