### PR TITLE
docs: Update slack link

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ A tool that validates [General Transit Feed Specification (GTFS)-realtime](https
 
 Read more in [this Medium article](https://medium.com/@sjbarbeau/introducing-the-gtfs-realtime-validator-e1aae3185439).
 
-Questions? You can [open an issue](https://github.com/MobilityData/gtfs-realtime-validator/issues), ask the [MobilityData Slack Group](https://mobilitydata-io.herokuapp.com/) or reach out to the [GTFS-realtime Google Group](https://groups.google.com/forum/#!forum/gtfs-realtime).
+Questions? You can [open an issue](https://github.com/MobilityData/gtfs-realtime-validator/issues), ask the [MobilityData Slack Group](https://bit.ly/mobilitydata-slack) or reach out to the [GTFS-realtime Google Group](https://groups.google.com/forum/#!forum/gtfs-realtime).
 
 ## Quick start - Run it yourself
 


### PR DESCRIPTION
**Summary:**

Update the MobilidyData slack link.
**Expected behavior:** 

The link works when we click on "MobilityData Slack Group" in README.md.
![Screen Shot 2022-03-10 at 5 55 45 PM](https://user-images.githubusercontent.com/63653518/157768832-521d916c-0fcc-49cb-a32c-bb6845fa7b88.png)

Please make sure these boxes are checked before submitting your pull request - thanks!

- [ ] ~~Run the unit tests with `mvn test` to make sure you didn't break anything~~
- [x] Format the title like "feat: {new feature short description}" or "fix: {describe what was fixed}". Title must follow the Conventional Commit Specification (https://www.conventionalcommits.org/en/v1.0.0/).
- [x] Linked all relevant issues
- [x] Include screenshot(s) showing how this pull request works and fixes the issue(s)
