### PR TITLE
fix: Bump Hibernate to 5.6.7.Final, use only named parameters in queries

### DIFF
--- a/gtfs-realtime-validator-lib/pom.xml
+++ b/gtfs-realtime-validator-lib/pom.xml
@@ -92,7 +92,7 @@
         <dependency>
             <groupId>org.hibernate</groupId>
             <artifactId>hibernate-core</artifactId>
-            <version>5.2.18.Final</version>
+            <version>5.6.7.Final</version>
         </dependency>
         <dependency>
             <groupId>org.javassist</groupId>

--- a/gtfs-realtime-validator-lib/src/main/java/edu/usf/cutr/gtfsrtvalidator/lib/model/ViewErrorLogModel.java
+++ b/gtfs-realtime-validator-lib/src/main/java/edu/usf/cutr/gtfsrtvalidator/lib/model/ViewErrorLogModel.java
@@ -25,7 +25,7 @@ import java.io.Serializable;
 @Entity
 @NamedNativeQuery(name = "ErrorLogByrtfeedID",
         query = // Retrieve the remaining columns, title and severity from Error and FinalResult tables on matching errorIds.
-                "SELECT rowIdentifier, ? AS rtFeedID, errorId AS id, " +
+                "SELECT rowIdentifier, :gtfsRtId1 AS rtFeedID, errorId AS id, " +
                     "Error.title, Error.severity, iterationId, occurrence, loggingTime " +
                 "FROM Error " +
                 "INNER JOIN " +
@@ -50,9 +50,9 @@ import java.io.Serializable;
                                     "INNER JOIN " +
                                     "(SELECT  IterationID, IterationTimestamp, feedTimestamp " +
                                     "FROM GtfsRtFeedIteration " +
-                                    "WHERE rtFeedID = ?) GtfsRtFeedIDIteration " +
+                                    "WHERE rtFeedID = :gtfsRtId2) GtfsRtFeedIDIteration " +
                                     "ON MessageLog.iterationID = GtfsRtFeedIDIteration.IterationID " +
-                                        "AND IterationTimestamp >= ? AND IterationTimestamp <= ? " +
+                                        "AND IterationTimestamp >= :sessionStartTime AND IterationTimestamp <= :sessionEndTime " +
                                 ") errorLog " +
                             "ORDER BY IterationID " +
                             ") " +

--- a/gtfs-realtime-validator-lib/src/main/java/edu/usf/cutr/gtfsrtvalidator/lib/model/ViewErrorSummaryModel.java
+++ b/gtfs-realtime-validator-lib/src/main/java/edu/usf/cutr/gtfsrtvalidator/lib/model/ViewErrorSummaryModel.java
@@ -24,7 +24,7 @@ import java.io.Serializable;
 @XmlRootElement
 @Entity
 @NamedNativeQuery(name = "ErrorSummaryByrtfeedID",
-    query = "SELECT ? AS rtFeedID, errorID AS id, " +
+    query = "SELECT :gtfsRtId1 AS rtFeedID, errorID AS id, " +
                 "title, severity, totalCount, lastTime, " +
                 "lastFeedTime, lastIterationId, lastRowId " +
             "FROM Error " +
@@ -51,9 +51,9 @@ import java.io.Serializable;
                                 "INNER JOIN " +
                                 "(SELECT  IterationID, IterationTimestamp, feedTimestamp " +
                                 "FROM GtfsRtFeedIteration " +
-                                "WHERE rtFeedID = ?) GtfsRtFeedIDIteration " +
+                                "WHERE rtFeedID = :gtfsRtId2) GtfsRtFeedIDIteration " +
                             "ON MessageLog.iterationID = GtfsRtFeedIDIteration.IterationID " +
-                                "AND IterationTimestamp >= ? AND IterationTimestamp <= ? " +
+                                "AND IterationTimestamp >= :sessionStartTime AND IterationTimestamp <= :sessionEndTime " +
                             ") errorLog " +
                             "ORDER BY iterationId " +
                         ") " +

--- a/gtfs-realtime-validator-lib/src/main/java/edu/usf/cutr/gtfsrtvalidator/lib/model/ViewFeedIterationsCount.java
+++ b/gtfs-realtime-validator-lib/src/main/java/edu/usf/cutr/gtfsrtvalidator/lib/model/ViewFeedIterationsCount.java
@@ -28,8 +28,8 @@ import javax.xml.bind.annotation.XmlRootElement;
 @NamedNativeQuery(name = "feedIterationsCount",
         query = "SELECT count(IterationID) AS iterationCount " +
                 "FROM GtfsRtFeedIteration " +
-                "WHERE rtFeedID = ? " +
-                    "AND IterationTimestamp >= ? AND IterationTimestamp <= ? ",
+                "WHERE rtFeedID = :gtfsRtId " +
+                    "AND IterationTimestamp >= :sessionStartTime AND IterationTimestamp <= :sessionEndTime ",
         resultClass = ViewFeedIterationsCount.class)
 public class ViewFeedIterationsCount {
 

--- a/gtfs-realtime-validator-lib/src/main/java/edu/usf/cutr/gtfsrtvalidator/lib/model/ViewFeedMessageModel.java
+++ b/gtfs-realtime-validator-lib/src/main/java/edu/usf/cutr/gtfsrtvalidator/lib/model/ViewFeedMessageModel.java
@@ -31,12 +31,12 @@ import java.io.InputStream;
     @NamedNativeQuery (name = "feedMessageByIterationId",
             query = "SELECT feedProtobuf AS feedMessage " +
                     "FROM GtfsRtFeedIteration " +
-                    "WHERE IterationID = ? ",
+                    "WHERE IterationID = :iterationId ",
             resultClass = ViewFeedMessageModel.class),
     @NamedNativeQuery (name = "feedMessageByGtfsRtId",
             query = "SELECT feedProtobuf AS feedMessage " +
                     "FROM GtfsRtFeedIteration " +
-                    "WHERE rtFeedId = ?  ORDER BY IterationTimestamp DESC",
+                    "WHERE rtFeedId = :gtfsRtId  ORDER BY IterationTimestamp DESC",
             resultClass = ViewFeedMessageModel.class)
 })
 public class ViewFeedMessageModel {

--- a/gtfs-realtime-validator-lib/src/main/java/edu/usf/cutr/gtfsrtvalidator/lib/model/ViewFeedUniqueResponseCount.java
+++ b/gtfs-realtime-validator-lib/src/main/java/edu/usf/cutr/gtfsrtvalidator/lib/model/ViewFeedUniqueResponseCount.java
@@ -28,8 +28,8 @@ import javax.xml.bind.annotation.XmlRootElement;
 @NamedNativeQuery(name = "feedUniqueResponseCount",
         query = "SELECT count(*) AS uniqueFeedCount " +
                 "FROM GtfsRtFeedIteration " +
-                "WHERE (rtFeedID = ? " +
-                    "AND IterationTimestamp >= ? AND IterationTimestamp <= ? " +
+                "WHERE (rtFeedID = :gtfsRtId " +
+                    "AND IterationTimestamp >= :sessionStartTime AND IterationTimestamp <= :sessionEndTime " +
                     "AND feedProtobuf IS NOT NULL) ",
         resultClass = ViewFeedUniqueResponseCount.class)
 public class ViewFeedUniqueResponseCount {

--- a/gtfs-realtime-validator-lib/src/main/java/edu/usf/cutr/gtfsrtvalidator/lib/model/ViewGtfsRtFeedErrorCountModel.java
+++ b/gtfs-realtime-validator-lib/src/main/java/edu/usf/cutr/gtfsrtvalidator/lib/model/ViewGtfsRtFeedErrorCountModel.java
@@ -36,9 +36,9 @@ import javax.xml.bind.annotation.XmlRootElement;
                 "INNER JOIN " +
                 "(SELECT IterationID, IterationTimestamp " +
                 "FROM GtfsRtFeedIteration " +
-                "WHERE rtFeedID = ?) GtfsRtFeedIDIteration " +
+                "WHERE rtFeedID = :gtfsRtId) GtfsRtFeedIDIteration " +
                 "ON MessageLog.iterationID = GtfsRtFeedIDIteration.IterationID " +
-                    "AND IterationTimestamp >= ? AND IterationTimestamp <= ? " +
+                    "AND IterationTimestamp >= :sessionStartTime AND IterationTimestamp <= :sessionEndTime " +
                 "GROUP BY errorID) errorCount " +
                 "ON Error.errorID = errorCount.errorID ",
         resultClass = ViewGtfsRtFeedErrorCountModel.class)

--- a/gtfs-realtime-validator-lib/src/main/java/edu/usf/cutr/gtfsrtvalidator/lib/model/ViewIterationErrorsModel.java
+++ b/gtfs-realtime-validator-lib/src/main/java/edu/usf/cutr/gtfsrtvalidator/lib/model/ViewIterationErrorsModel.java
@@ -35,9 +35,9 @@ import javax.xml.bind.annotation.XmlRootElement;
                     "INNER JOIN " +
                         "(SELECT messageId, errorId " +
                         "FROM MessageLog " +
-                        "WHERE iterationId = ?) MessageLogIteration " +
+                        "WHERE iterationId = :iterationId) MessageLogIteration " +
                     "ON Occurrence.messageId = MessageLogIteration.messageId " +
-                    "WHERE messageId = ? ) OccurrenceList " +
+                    "WHERE messageId = :messageId ) OccurrenceList " +
                 "ON Error.errorId = OccurrenceList.errorId " +
                 "ORDER BY occurrenceId ",
         resultClass = ViewIterationErrorsModel.class)

--- a/gtfs-realtime-validator-webapp/pom.xml
+++ b/gtfs-realtime-validator-webapp/pom.xml
@@ -139,7 +139,7 @@
         <dependency>
             <groupId>org.hibernate</groupId>
             <artifactId>hibernate-core</artifactId>
-            <version>5.2.18.Final</version>
+            <version>5.6.7.Final</version>
         </dependency>
         <dependency>
             <groupId>org.javassist</groupId>

--- a/gtfs-realtime-validator-webapp/src/main/java/edu/usf/cutr/gtfsrtvalidator/api/resource/GtfsRtFeed.java
+++ b/gtfs-realtime-validator-webapp/src/main/java/edu/usf/cutr/gtfsrtvalidator/api/resource/GtfsRtFeed.java
@@ -197,35 +197,35 @@ public class GtfsRtFeed {
 
         ViewFeedIterationsCount iterationsCount;
         iterationsCount = (ViewFeedIterationsCount) session.createNamedQuery("feedIterationsCount", ViewFeedIterationsCount.class)
-                .setParameter(0, gtfsRtId)
-                .setParameter(1, sessionStartTime)
-                .setParameter(2, sessionEndTime)
+                .setParameter("gtfsRtId", gtfsRtId)
+                .setParameter("sessionStartTime", sessionStartTime)
+                .setParameter("sessionEndTime", sessionEndTime)
                 .uniqueResult();
         mergeMonitorData.setIterationCount(iterationsCount.getIterationCount());
 
         ViewFeedUniqueResponseCount uniqueResponseCount;
         uniqueResponseCount = (ViewFeedUniqueResponseCount) session.createNamedQuery("feedUniqueResponseCount", ViewFeedUniqueResponseCount.class)
-                .setParameter(0, gtfsRtId)
-                .setParameter(1, sessionStartTime)
-                .setParameter(2, sessionEndTime)
+                .setParameter("gtfsRtId", gtfsRtId)
+                .setParameter("sessionStartTime", sessionStartTime)
+                .setParameter("sessionEndTime", sessionEndTime)
                 .uniqueResult();
         mergeMonitorData.setUniqueFeedCount(uniqueResponseCount.getUniqueFeedCount());
 
         List<ViewGtfsRtFeedErrorCountModel> viewGtfsRtFeedErrorCountModel;
         viewGtfsRtFeedErrorCountModel = session.createNamedQuery("feedErrorCount", ViewGtfsRtFeedErrorCountModel.class)
-                .setParameter(0, gtfsRtId)
-                .setParameter(1, sessionStartTime)
-                .setParameter(2, sessionEndTime)
+                .setParameter("gtfsRtId", gtfsRtId)
+                .setParameter("sessionStartTime", sessionStartTime)
+                .setParameter("sessionEndTime", sessionEndTime)
                 .list();
         mergeMonitorData.setViewGtfsRtFeedErrorCountModelList(viewGtfsRtFeedErrorCountModel);
 
         List<ViewErrorSummaryModel> feedSummary;
         int fromRow = (summaryCurPage - 1) * summaryRowsPerPage;
         feedSummary = session.createNamedQuery("ErrorSummaryByrtfeedID", ViewErrorSummaryModel.class)
-                .setParameter(0, gtfsRtId)
-                .setParameter(1, gtfsRtId)
-                .setParameter(2, sessionStartTime)
-                .setParameter(3, sessionEndTime)
+                .setParameter("gtfsRtId1", gtfsRtId)
+                .setParameter("gtfsRtId2", gtfsRtId)
+                .setParameter("sessionStartTime", sessionStartTime)
+                .setParameter("sessionEndTime", sessionEndTime)
                 .setFirstResult(fromRow)
                 .setMaxResults(summaryRowsPerPage)
                 .list();
@@ -245,10 +245,10 @@ public class GtfsRtFeed {
         // Getting the value of fromRow from the rowsPerPage and currentPage values.
         fromRow = (logCurPage - 1) * logRowsPerPage;
         feedLog = session.createNamedQuery("ErrorLogByrtfeedID", ViewErrorLogModel.class)
-                .setParameter(0, gtfsRtId)
-                .setParameter(1, gtfsRtId)
-                .setParameter(2, sessionStartTime)
-                .setParameter(3, sessionEndTime)
+                .setParameter("gtfsRtId1", gtfsRtId)
+                .setParameter("gtfsRtId2", gtfsRtId)
+                .setParameter("sessionStartTime", sessionStartTime)
+                .setParameter("sessionEndTime", sessionEndTime)
                 .setParameterList("errorIds", removeIds)
                 .setFirstResult(fromRow)
                 .setMaxResults(logRowsPerPage)
@@ -279,11 +279,11 @@ public class GtfsRtFeed {
          Session session = GTFSDB.initSessionBeginTrans();
          if(iterationId != -1) {
              feedMessageModel = session.createNamedQuery("feedMessageByIterationId", ViewFeedMessageModel.class)
-                 .setParameter(0, iterationId)
+                 .setParameter("iterationId", iterationId)
                  .uniqueResult();
          } else {
              feedMessageModel = session.createNamedQuery("feedMessageByGtfsRtId", ViewFeedMessageModel.class)
-                     .setParameter(0, gtfsRtId)
+                     .setParameter("gtfsRtId", gtfsRtId)
                      .setMaxResults(1).getSingleResult();
          }
 
@@ -329,8 +329,8 @@ public class GtfsRtFeed {
         for (int messageId: messageIdList) {
             session = GTFSDB.initSessionBeginTrans();
             viewIterationErrorsModelList = session.createNamedQuery("IterationIdErrors", ViewIterationErrorsModel.class)
-                    .setParameter(0, iterationId)
-                    .setParameter(1, messageId)
+                    .setParameter("iterationId", iterationId)
+                    .setParameter("messageId", messageId)
                     .list();
             GTFSDB.closeSession(session);
             if (!viewIterationErrorsModelList.isEmpty()) {


### PR DESCRIPTION
**Summary:**

This PR bumps the Hibernate version to 5.6.7.Final. However, errors are encountered:

```
javax.servlet.ServletException: java.lang.IllegalArgumentException: Could not locate ordinal parameter [0], expecting one of [1, 2, 3]
...
```

Full stack trace is detailed in https://github.com/MobilityData/gtfs-realtime-validator/issues/139.

**EDIT** - Problems seem to be solved by using named parameters only in queries - see https://github.com/MobilityData/gtfs-realtime-validator/pull/140#issuecomment-1076840004.

Closes #139.

**Expected behavior:** 

Everything should work as it previously did on the main branch - website should show validation results. ~~However, the website currently appears blank.~~

Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] Run the unit tests with `mvn test` to make sure you didn't break anything
- [x] Format the title like "feat: {new feature short description}" or "fix: {describe what was fixed}". Title must follow the Conventional Commit Specification (https://www.conventionalcommits.org/en/v1.0.0/).
- [x] Linked all relevant issues
- [x] Include screenshot(s) showing how this pull request works and fixes the issue(s)
