### PR TITLE
chore: Update in-app repo links from CUTR-at-USF->MobilityData

### DIFF
--- a/gtfs-realtime-validator-webapp/src/main/java/edu/usf/cutr/gtfsrtvalidator/api/resource/GtfsFeed.java
+++ b/gtfs-realtime-validator-webapp/src/main/java/edu/usf/cutr/gtfsrtvalidator/api/resource/GtfsFeed.java
@@ -128,7 +128,8 @@ public class GtfsFeed {
         if (response == Response.Status.BAD_REQUEST) {
             return generateError("Download Failed", "Downloading static GTFS feed from provided Url failed.", Response.Status.BAD_REQUEST);
         } else if (response == Response.Status.FORBIDDEN) {
-            return generateError("SSL Handshake Failed", "SSL handshake failed.  Try installing the JCE Extension - see https://github.com/CUTR-at-USF/gtfs-realtime-validator#prerequisites", Response.Status.FORBIDDEN);
+            // TODO - Needs further testing to determine better error message on Java 11 and up (JCE Extension is no longer required there)
+            return generateError("SSL Handshake Failed", "SSL handshake failed.  Try installing the JCE Extension if you're running Java 8 - see https://github.com/CUTR-at-USF/gtfs-realtime-validator/blob/fca9c73b3d3b377c606065648750b777d36ad553/README.md#prerequisites-1", Response.Status.FORBIDDEN);
         }
 
         _log.info("GTFS zip file downloaded successfully");
@@ -308,7 +309,8 @@ public class GtfsFeed {
             try {
                 inputStream = connection.getInputStream();
             } catch (SSLHandshakeException sslEx) {
-                _log.error("SSL handshake failed.  Try installing the JCE Extension - see https://github.com/CUTR-at-USF/gtfs-realtime-validator#prerequisites", sslEx);
+                // TODO - Needs further testing to determine better error message on Java 11 and up (JCE Extension is no longer required there)
+                _log.error("SSL handshake failed.  Try installing the JCE Extension if you're running Java 8 - see https://github.com/CUTR-at-USF/gtfs-realtime-validator/blob/fca9c73b3d3b377c606065648750b777d36ad553/README.md#prerequisites-1", sslEx);
                 return Response.Status.FORBIDDEN;
             }
 

--- a/gtfs-realtime-validator-webapp/src/main/resources/webroot/index.html
+++ b/gtfs-realtime-validator-webapp/src/main/resources/webroot/index.html
@@ -51,7 +51,7 @@
                     both those explicitly listed in the spec and those based on the needs of consuming applications.</p>
 
                 <p>The rules that this tool uses to validate feeds are listed
-                    <a href="https://github.com/CUTR-at-USF/gtfs-realtime-validator/blob/master/RULES.md">here</a>
+                    <a href="https://github.com/MobilityData/gtfs-realtime-validator/blob/master/RULES.md">here</a>
                 </p>
             </div>
         </div>

--- a/gtfs-realtime-validator-webapp/src/main/resources/webroot/iteration.html
+++ b/gtfs-realtime-validator-webapp/src/main/resources/webroot/iteration.html
@@ -82,7 +82,7 @@
         <div class="well each-card">
             <div class="col-md-12">
                 <h4 class="col-md-11">
-                    <span><a href="https://github.com/CUTR-at-USF/gtfs-realtime-validator/blob/master/RULES.md#{{errorId}}" target="_blank">{{errorId}}</a></span>
+                    <span><a href="https://github.com/MobilityData/gtfs-realtime-validator/blob/master/RULES.md#{{errorId}}" target="_blank">{{errorId}}</a></span>
                     <span> - {{title}}</span>
                 </h4>
                 <div class="col-md-1 download-button" id="download-button-{{@index}}">

--- a/gtfs-realtime-validator-webapp/src/main/resources/webroot/monitoring.html
+++ b/gtfs-realtime-validator-webapp/src/main/resources/webroot/monitoring.html
@@ -192,7 +192,7 @@
 <script id="feed-monitor-summary-row-template" type="text/x-handlebars-template">
     {{#each this}}
     <tr>
-        <td> <a href="https://github.com/CUTR-at-USF/gtfs-realtime-validator/blob/master/RULES.md#{{id}}" target="_blank">{{id}}</a> </td>
+        <td> <a href="https://github.com/MobilityData/gtfs-realtime-validator/blob/master/RULES.md#{{id}}" target="_blank">{{id}}</a> </td>
         <td>{{title}}</td>
 
         <td>{{severity}}</td>
@@ -209,7 +209,7 @@
     {{#each this}}
     <tr>
         <td><a href="iteration.html?iteration={{iterationId}}&sessionIteration={{rowId}}&gtfsRtId={{gtfsRtId}}" target="_blank">{{rowId}}</a></td>
-        <td><a href="https://github.com/CUTR-at-USF/gtfs-realtime-validator/blob/master/RULES.md#{{id}}" target="_blank">{{id}}</a></td>
+        <td><a href="https://github.com/MobilityData/gtfs-realtime-validator/blob/master/RULES.md#{{id}}" target="_blank">{{id}}</a></td>
         <td>{{title}}</td>
 
         <td>{{severity}}</td>

--- a/gtfs-realtime-validator-webapp/src/main/resources/webroot/session-monitor.html
+++ b/gtfs-realtime-validator-webapp/src/main/resources/webroot/session-monitor.html
@@ -104,7 +104,7 @@
 <script id="feed-monitor-summary-row-template" type="text/x-handlebars-template">
     {{#each this}}
     <tr>
-        <td> <a href="https://github.com/CUTR-at-USF/gtfs-realtime-validator/blob/master/RULES.md#{{id}}" target="_blank">{{id}}</a> </td>
+        <td> <a href="https://github.com/MobilityData/gtfs-realtime-validator/blob/master/RULES.md#{{id}}" target="_blank">{{id}}</a> </td>
         <td>{{title}}</td>
 
         <td>{{severity}}</td>

--- a/gtfs-realtime-validator-webapp/src/test/java/edu/usf/cutr/gtfsrtvalidator/api/resource/GtfsFeedTest.java
+++ b/gtfs-realtime-validator-webapp/src/test/java/edu/usf/cutr/gtfsrtvalidator/api/resource/GtfsFeedTest.java
@@ -32,10 +32,10 @@ import java.util.List;
  */
 public class GtfsFeedTest extends TestCase {
 
-    private final String validGtfsFeedURL = "https://github.com/CUTR-at-USF/gtfs-realtime-validator/raw/master/gtfs-realtime-validator-webapp/src/test/resources/bullrunner-gtfs.zip";
+    private final String validGtfsFeedURL = "https://github.com/MobilityData/gtfs-realtime-validator/raw/master/gtfs-realtime-validator-webapp/src/test/resources/bullrunner-gtfs.zip";
     private final String invalidGtfsFeedURL = "DUMMY";
     private final String downloadFailURL = "http://gohart.org/google/file_not_exist.zip";
-    private final String badGTFS = "https://github.com/CUTR-at-USF/gtfs-realtime-validator/raw/master/gtfs-realtime-validator-webapp/src/test/resources/badgtfs.zip";
+    private final String badGTFS = "https://github.com/MobilityData/gtfs-realtime-validator/raw/master/gtfs-realtime-validator-webapp/src/test/resources/badgtfs.zip";
 
     private GtfsFeed mGtfsFeed;
 


### PR DESCRIPTION
**Summary:**

In several parts of the application URLs to the CUTR repo still existed:
1. For downloading unit test data
2. In webapp links (e.g., clicking on the error code in the error message to go to RULES.md)
3. In logs

I've updated these to point to the MobilityData repo instead.

Note that I've left other URLs in comments pointing at the CUTR repo, because those often reference specific issues and comments relevant to the history of certain changes.

**Expected behavior:** 

Various links above now point to MobilityData GitHub repo instead of CUTR.

Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] Run the unit tests with `mvn test` to make sure you didn't break anything
- [x] Format the title like "feat: {new feature short description}" or "fix: {describe what was fixed}". Title must follow the Conventional Commit Specification (https://www.conventionalcommits.org/en/v1.0.0/).
- [x] Linked all relevant issues
- [x] Include screenshot(s) showing how this pull request works and fixes the issue(s)
