### PR TITLE
chore: Bump Jackson version

### DIFF
--- a/gtfs-realtime-validator-lib/pom.xml
+++ b/gtfs-realtime-validator-lib/pom.xml
@@ -18,24 +18,24 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-core</artifactId>
-            <version>2.9.8</version>
+            <version>2.13.2</version>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.9.10.8</version>
+            <version>2.13.2.1</version>
         </dependency>
         <!-- starting with Java 11 these libraries are no longer part of the JRE by default
              therefore they have to be added as ordinary dependencies -->
         <dependency>
             <groupId>jakarta.xml.bind</groupId>
             <artifactId>jakarta.xml.bind-api</artifactId>
-            <version>2.3.3</version>
+            <version>3.0.1</version>
         </dependency>
         <dependency>
             <groupId>com.sun.xml.bind</groupId>
             <artifactId>jaxb-impl</artifactId>
-            <version>2.3.3</version>
+            <version>3.0.2</version>
             <scope>runtime</scope>
         </dependency>
         <!-- GTFS-to-Java objects -->

--- a/gtfs-realtime-validator-webapp/pom.xml
+++ b/gtfs-realtime-validator-webapp/pom.xml
@@ -48,7 +48,7 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-core</artifactId>
-            <version>2.9.7</version>
+            <version>2.13.2</version>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
**Summary:**

Bumps the Jackson libraries and related libraries to the latest version.

I've tested the webapp on Windows 10 w/ JDK 17.0.2 and it works correctly.

**Expected behavior:** 

No change from main branch

Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] Run the unit tests with `mvn test` to make sure you didn't break anything
- [x] Format the title like "feat: {new feature short description}" or "fix: {describe what was fixed}". Title must follow the Conventional Commit Specification (https://www.conventionalcommits.org/en/v1.0.0/).
- [x] Linked all relevant issues
- [x] Include screenshot(s) showing how this pull request works and fixes the issue(s)
