### PR TITLE
docs: Update "Troubleshooting" to include configuration for ignoring shapes.txt

### DIFF
--- a/TROUBLESHOOTING.md
+++ b/TROUBLESHOOTING.md
@@ -17,3 +17,38 @@ Try including the `java.xml.bind` module with the `--add-modules` parameter:
 *Symptom* - I use `java -Djsee.enableSNIExtension=false ...` as instructed to run the app when retrieving GTFS or GTFS Realtime feeds from HTTPS URLs over SSL, but it fails with an error like `javax.net.ssl.SSLHandshakeException: java.security.cert.CertificateException: No subject alternative DNS name matching www.donneesquebec.ca found.` 
 
 *Solution* - The underlying problem is probably with the server certificate configuration where the GTFS or GTFS Realtime data is hosted.  You can try to change the parameter to `-Djsse.enableSNIExtension=true` instead, which has helped [in the past](https://github.com/CUTR-at-USF/gtfs-realtime-validator/pull/310) for Linux deployments.
+
+### `java.lang.OutOfMemoryError: Java heap space` when running project
+
+*Symptom* - I try to run the application on a dataset and I get an error that looks like:
+
+```
+[main] INFO edu.usf.cutr.gtfsrtvalidator.lib.batch.BatchProcessor - Starting batch processor...
+[main] INFO edu.usf.cutr.gtfsrtvalidator.lib.batch.BatchProcessor - Reading GTFS data from /tmp/validation_165096_gtfs_rt/file.zip...
+[main] INFO edu.usf.cutr.gtfsrtvalidator.lib.batch.BatchProcessor - file.zip read in 16.145 seconds
+[main] INFO edu.usf.cutr.gtfsrtvalidator.lib.validation.GtfsMetadata - Building GtfsMetadata for /tmp/validation_165096_gtfs_rt/file.zip...
+[main] INFO edu.usf.cutr.gtfsrtvalidator.lib.validation.GtfsMetadata - Processing trips and building trip shapes for /tmp/validation_165096_gtfs_rt/file.zip...
+Exception in thread \"main\" java.lang.OutOfMemoryError: Java heap space
+    at org.locationtech.spatial4j.shape.jts.JtsShapeFactory$CoordinatesAccumulator.pointXYZ(JtsShapeFactory.java:316)
+    at org.locationtech.spatial4j.shape.jts.JtsShapeFactory$CoordinatesAccumulator.pointXY(JtsShapeFactory.java:310)
+	at org.locationtech.spatial4j.shape.jts.JtsShapeFactory$JtsLineStringBuilder.pointXY(JtsShapeFactory.java:228)
+	at edu.usf.cutr.gtfsrtvalidator.lib.validation.GtfsMetadata.<init>(GtfsMetadata.java:184)
+	at edu.usf.cutr.gtfsrtvalidator.lib.batch.BatchProcessor.processFeeds(BatchProcessor.java:145)
+	at edu.usf.cutr.gtfsrtvalidator.lib.Main.main(Main.java:62)"
+```
+
+*Solution* - Typically you can fix a `java.lang.OutOfMemoryError: Java heap space` by increasing the heap size using the following command-line parameters when running the batch validator:
+
+```
+java ... -Xmx512m -XX:MaxMetaspaceSize=512m
+```
+
+See [this StackOverflow post](https://stackoverflow.com/a/38336005/937715) for more details.
+
+If you don't want to allocate more memory to the batch validator, note that you can typically avoid OOM errors on larger feeds by ignoring the rules that process shapes.txt file by adding the command line parameter:
+
+`-ignoreShapes yes`
+
+Note that setting this to true will prevent the validator from checking rules like E029 that require spatial data.
+
+See the [batch processor command-line parameters](https://github.com/MobilityData/gtfs-realtime-validator/blob/master/gtfs-realtime-validator-lib/README.md#command-line-config-parameters) for details.

--- a/TROUBLESHOOTING.md
+++ b/TROUBLESHOOTING.md
@@ -45,7 +45,7 @@ java ... -Xmx512m -XX:MaxMetaspaceSize=512m
 
 See [this StackOverflow post](https://stackoverflow.com/a/38336005/937715) for more details.
 
-If you don't want to allocate more memory to the batch validator, note that you can typically avoid OOM errors on larger feeds by ignoring the rules that process shapes.txt file by adding the command line parameter:
+If you can't allocate more memory to the batch validator, note that you can typically avoid OOM errors on larger feeds by ignoring the rules that process shapes.txt file by adding the command line parameter:
 
 `-ignoreShapes yes`
 


### PR DESCRIPTION
**Summary:**

A common situation that deployers of the validator may encounter when validating large GTFS files is `java.lang.OutOfMemoryError: Java heap space`. 

See https://github.com/etalab/transport-site/issues/2212 for an example. We hit this ourselves when processing large country-size datasets like the Netherlands.

This PR adds this scenario to the "Troubleshooting" file as well as different possible solutions.

**Expected behavior:** 

Explain what to do when hitting `java.lang.OutOfMemoryError: Java heap space` in "Troubleshooting" file

Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] Run the unit tests with `mvn test` to make sure you didn't break anything
- [x] Format the title like "feat: {new feature short description}" or "fix: {describe what was fixed}". Title must follow the Conventional Commit Specification (https://www.conventionalcommits.org/en/v1.0.0/).
- [x] Linked all relevant issues
- [x] Include screenshot(s) showing how this pull request works and fixes the issue(s)
