### PR TITLE
fix: Use JDK 11 in Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,10 @@
-FROM maven:3-jdk-8 AS build
+FROM maven:3.8.5-jdk-11-slim AS build
 
 WORKDIR /build
 COPY ./ .
 RUN mvn package
 
-FROM openjdk:8-alpine AS final
+FROM openjdk:11 AS final
 EXPOSE 8080
 ENTRYPOINT ["java", "-Djsee.enableSNIExtension=false", "-jar", "gtfs-realtime-validator-webapp-1.0.0-SNAPSHOT.jar"]
 CMD []


### PR DESCRIPTION
**Summary:**

This is an attempt to fix https://github.com/MobilityData/gtfs-realtime-validator/issues/148 by updating the Docker image to use JDK 11.

Closes https://github.com/MobilityData/gtfs-realtime-validator/issues/148.

**Expected behavior:** 

Docker image should work same as before but use JDK 11 instead of JDK 8.

Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] Run the unit tests with `mvn test` to make sure you didn't break anything
- [x] Format the title like "feat: {new feature short description}" or "fix: {describe what was fixed}". Title must follow the Conventional Commit Specification (https://www.conventionalcommits.org/en/v1.0.0/).
- [x] Linked all relevant issues
- [x] Include screenshot(s) showing how this pull request works and fixes the issue(s)
