### PR TITLE
fix: Bump conveyal artifacts to version `0.1.8`

### DIFF
--- a/gtfs-realtime-validator-webapp/pom.xml
+++ b/gtfs-realtime-validator-webapp/pom.xml
@@ -128,12 +128,12 @@
         <dependency>
             <groupId>com.conveyal</groupId>
             <artifactId>gtfs-validation-lib</artifactId>
-            <version>0.1.7-SNAPSHOT</version>
+            <version>0.1.8</version>
         </dependency>
         <dependency>
             <groupId>com.conveyal</groupId>
             <artifactId>gtfs-validator-json</artifactId>
-            <version>0.1.7-SNAPSHOT</version>
+            <version>0.1.8</version>
         </dependency>
         <!-- Hibernate -->
         <dependency>


### PR DESCRIPTION
The `0.1.7-SNAPSHOT` cannot be found, which is keeping the project from building.

- [x] Run the unit tests with `mvn test` to make sure you didn't break anything
- [x] Format the title like "feat: {new feature short description}" or "fix: {describe what was fixed}". Title must follow the Conventional Commit Specification (https://www.conventionalcommits.org/en/v1.0.0/).
- [ ] Linked all relevant issues
- [ ] Include screenshot(s) showing how this pull request works and fixes the issue(s)
