### PR TITLE
fix: E026 - 0,0 is invalid vehicle coordinate

### DIFF
--- a/gtfs-realtime-validator-lib/src/main/java/edu/usf/cutr/gtfsrtvalidator/lib/util/GtfsUtils.java
+++ b/gtfs-realtime-validator-lib/src/main/java/edu/usf/cutr/gtfsrtvalidator/lib/util/GtfsUtils.java
@@ -140,6 +140,9 @@ public class GtfsUtils {
         if (position.getLongitude() < -180f || position.getLongitude() > 180f) {
             return false;
         }
+        if (position.getLongitude() == 0f && position.getLongitude() == 0f) {
+            return false;
+        }
         return true;
     }
 

--- a/gtfs-realtime-validator-lib/src/test/java/edu/usf/cutr/gtfsrtvalidator/lib/test/UtilTest.java
+++ b/gtfs-realtime-validator-lib/src/test/java/edu/usf/cutr/gtfsrtvalidator/lib/test/UtilTest.java
@@ -451,10 +451,6 @@ public class UtilTest {
         /**
          * Valid lat/longs
          */
-        positionBuilder.setLatitude(0);
-        positionBuilder.setLongitude(0);
-
-        assertEquals(true, GtfsUtils.isPositionValid(positionBuilder.build()));
 
         positionBuilder.setLatitude(-90);
         positionBuilder.setLongitude(-180);
@@ -469,6 +465,11 @@ public class UtilTest {
         /**
          * Bad lat or long
          */
+        positionBuilder.setLatitude(0);
+        positionBuilder.setLongitude(0);
+
+        assertEquals(false, GtfsUtils.isPositionValid(positionBuilder.build()));
+
         positionBuilder.setLatitude(-91);
         positionBuilder.setLongitude(0);
 

--- a/gtfs-realtime-validator-lib/src/test/java/edu/usf/cutr/gtfsrtvalidator/lib/test/rules/VehicleValidatorTest.java
+++ b/gtfs-realtime-validator-lib/src/test/java/edu/usf/cutr/gtfsrtvalidator/lib/test/rules/VehicleValidatorTest.java
@@ -231,6 +231,21 @@ public class VehicleValidatorTest extends FeedMessageTest {
         expected.put(E026, 1);
         TestUtils.assertResults(expected, results);
 
+        // Invalid lat & long - 1 error
+        positionBuilder.setLatitude(0f);
+        positionBuilder.setLongitude(0f);
+
+        vehiclePositionBuilder.setPosition(positionBuilder.build());
+
+        vehiclePositionBuilder.setVehicle(vehicleDescriptorBuilder.build());
+        feedEntityBuilder.setVehicle(vehiclePositionBuilder.build());
+        feedMessageBuilder.setEntity(0, feedEntityBuilder.build());
+
+        results = vehicleValidator.validate(MIN_POSIX_TIME, bullRunnerGtfs, bullRunnerGtfsMetadata, feedMessageBuilder.build(), null, null);
+        expected.put(E026, 1);
+        TestUtils.assertResults(expected, results);
+
+
         clearAndInitRequiredFeedFields();
     }
 


### PR DESCRIPTION
**Summary:**

Addresses #77.  0,0 is invalid vehicle coordinate. Added check for vehicle location. Also updated `UtilTest.java` as it had a test with 0,0 as a valid coordinate. My understanding is it should be invalid here as well.

**Expected behavior:** 

Vehicle location with 0,0 as a coordinate should throw E026

Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] Run the unit tests with `mvn test` to make sure you didn't break anything
- [x] Format the title like "feat: {new feature short description}" or "fix: {describe what was fixed}". Title must follow the Conventional Commit Specification (https://www.conventionalcommits.org/en/v1.0.0/).
- [x] Linked all relevant issues
- [ ] Include screenshot(s) showing how this pull request works and fixes the issue(s) (N/A)
