### PR TITLE
Fix for deprecated of `set-output` in GH actions

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -49,9 +49,9 @@ jobs:
           if [ "${{ github.event_name }}" = "push" ]; then
             TAGS="${DOCKER_IMAGE}:latest"
           fi
-          echo ::set-output name=version::${VERSION}
-          echo ::set-output name=tags::${TAGS}
-          echo ::set-output name=created::$(date -u +'%Y-%m-%dT%H:%M:%SZ')
+          echo "version=${VERSION}" >> $GITHUB_OUTPUT
+          echo "tags=${TAGS}" >> $GITHUB_OUTPUT
+          echo "created=$(date -u +'%Y-%m-%dT%H:%M:%SZ')" >> $GITHUB_OUTPUT
       - name: Set up JDK 11
         uses: actions/setup-java@v2
         with:


### PR DESCRIPTION
GitHub has deprecated set-output and will eventually make it unusable, so this is a preventative fix. See more info here: https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/