### PR TITLE
fix(deps): upgrade onebusaway-gtfs dependency to fix crash when parsing areas.txt

### DIFF
--- a/gtfs-realtime-validator-lib/pom.xml
+++ b/gtfs-realtime-validator-lib/pom.xml
@@ -42,7 +42,7 @@
         <dependency>
             <groupId>org.onebusaway</groupId>
             <artifactId>onebusaway-gtfs</artifactId>
-            <version>1.3.87</version>
+            <version>3.1.0</version>
         </dependency>
         <!-- Command line parameter parsing -->
         <dependency>

--- a/gtfs-realtime-validator-lib/src/main/java/edu/usf/cutr/gtfsrtvalidator/lib/validation/gtfs/StopLocationTypeValidator.java
+++ b/gtfs-realtime-validator-lib/src/main/java/edu/usf/cutr/gtfsrtvalidator/lib/validation/gtfs/StopLocationTypeValidator.java
@@ -32,7 +32,8 @@ import java.util.*;
 import static edu.usf.cutr.gtfsrtvalidator.lib.validation.ValidationRules.E010;
 
 /**
- * E010 - If location_type is used in stops.txt, all stops referenced in stop_times.txt must have location_type of 0
+ * E010 - If location_type is used in stops.txt, all stops referenced in
+ * stop_times.txt must have location_type of 0
  */
 public class StopLocationTypeValidator implements GtfsFeedValidator {
 
@@ -46,12 +47,16 @@ public class StopLocationTypeValidator implements GtfsFeedValidator {
         Set<Stop> checkedStops = new HashSet<>();
 
         for (StopTime stopTime : stopTimes) {
-            if (!checkedStops.contains(stopTime.getStop())) {
-                checkedStops.add(stopTime.getStop());
+            if (stopTime.getStop() instanceof Stop) {
+                Stop stop = (Stop) stopTime.getStop();
+                if (!checkedStops.contains(stop)) {
+                    checkedStops.add(stop);
 
-                if (stopTime.getStop().getLocationType() != 0) {
-                    RuleUtils.addOccurrence(E010, "stop_id " + stopTime.getStop().getId(), e010List, _log);
+                    if (stop.getLocationType() != 0) {
+                        RuleUtils.addOccurrence(E010, "stop_id " + stopTime.getStop().getId(), e010List, _log);
+                    }
                 }
+
             }
         }
 

--- a/gtfs-realtime-validator-lib/src/main/java/edu/usf/cutr/gtfsrtvalidator/lib/validation/rules/StopTimeUpdateValidator.java
+++ b/gtfs-realtime-validator-lib/src/main/java/edu/usf/cutr/gtfsrtvalidator/lib/validation/rules/StopTimeUpdateValidator.java
@@ -40,8 +40,10 @@ import static com.google.transit.realtime.GtfsRealtime.TripUpdate.StopTimeUpdate
 import static com.google.transit.realtime.GtfsRealtime.TripUpdate.StopTimeUpdate.ScheduleRelationship.SKIPPED;
 
 /**
- * E002 - stop_time_updates for a given trip_id must be sorted by increasing stop_sequence
- * E009 - GTFS-rt stop_sequence isn't provided for trip that visits same stop_id more than once
+ * E002 - stop_time_updates for a given trip_id must be sorted by increasing
+ * stop_sequence
+ * E009 - GTFS-rt stop_sequence isn't provided for trip that visits same stop_id
+ * more than once
  * E036 - Sequential stop_time_updates have the same stop_sequence
  * E037 - Sequential stop_time_updates have the same stop_id
  * E040 - stop_time_update doesn't contain stop_id or stop_sequence
@@ -50,7 +52,8 @@ import static com.google.transit.realtime.GtfsRealtime.TripUpdate.StopTimeUpdate
  * E043 - stop_time_update doesn't have arrival or departure
  * E044 - stop_time_update arrival/departure doesn't have delay or time
  * E045 - GTFS-rt stop_time_update stop_sequence and stop_id do not match GTFS
- * E046 - GTFS-rt stop_time_update without time doesn't have arrival/departure_time in GTFS
+ * E046 - GTFS-rt stop_time_update without time doesn't have
+ * arrival/departure_time in GTFS
  * E051 - GTFS-rt stop_sequence not found in GTFS data
  */
 public class StopTimeUpdateValidator implements FeedEntityValidator {
@@ -58,7 +61,9 @@ public class StopTimeUpdateValidator implements FeedEntityValidator {
     private static final org.slf4j.Logger _log = LoggerFactory.getLogger(StopTimeUpdateValidator.class);
 
     @Override
-    public List<ErrorListHelperModel> validate(long currentTimeMillis, GtfsMutableDao gtfsData, GtfsMetadata gtfsMetadata, GtfsRealtime.FeedMessage feedMessage, GtfsRealtime.FeedMessage previousFeedMessage, GtfsRealtime.FeedMessage combinedFeedMessage) {
+    public List<ErrorListHelperModel> validate(long currentTimeMillis, GtfsMutableDao gtfsData,
+            GtfsMetadata gtfsMetadata, GtfsRealtime.FeedMessage feedMessage,
+            GtfsRealtime.FeedMessage previousFeedMessage, GtfsRealtime.FeedMessage combinedFeedMessage) {
         List<GtfsRealtime.FeedEntity> entityList = feedMessage.getEntityList();
         List<OccurrenceModel> e002List = new ArrayList<>();
         List<OccurrenceModel> e009List = new ArrayList<>();
@@ -96,11 +101,14 @@ public class StopTimeUpdateValidator implements FeedEntityValidator {
                 Map<String, List<String>> tripWithMultiStop = gtfsMetadata.getTripsWithMultiStops();
                 boolean unknownRtStopSequence = false;
                 for (GtfsRealtime.TripUpdate.StopTimeUpdate stopTimeUpdate : rtStopTimeUpdateList) {
-                    if (!foundE009error && tripId != null && tripWithMultiStop.containsKey(tripId) && !stopTimeUpdate.hasStopSequence()) {
-                        // E009 - GTFS-rt stop_sequence isn't provided for trip that visits same stop_id more than once
+                    if (!foundE009error && tripId != null && tripWithMultiStop.containsKey(tripId)
+                            && !stopTimeUpdate.hasStopSequence()) {
+                        // E009 - GTFS-rt stop_sequence isn't provided for trip that visits same stop_id
+                        // more than once
                         List<String> stopIds = tripWithMultiStop.get(tripId);
-                        RuleUtils.addOccurrence(ValidationRules.E009, "trip_id " + tripId + " visits stop_id " + stopIds.toString(), e009List, _log);
-                        foundE009error = true;  // Only log error once for this trip
+                        RuleUtils.addOccurrence(ValidationRules.E009,
+                                "trip_id " + tripId + " visits stop_id " + stopIds.toString(), e009List, _log);
+                        foundE009error = true; // Only log error once for this trip
                     }
                     if (previousRtStopSequence != null) {
                         checkE036(entity, previousRtStopSequence, stopTimeUpdate, e036List);
@@ -120,45 +128,53 @@ public class StopTimeUpdateValidator implements FeedEntityValidator {
                         // Loop through GTFS stop_time.txt to try and find a matching GTFS stop
                         while (gtfsStopTimeIndex < gtfsStopTimes.size()) {
                             int gtfsStopSequence = gtfsStopTimes.get(gtfsStopTimeIndex).getStopSequence();
-                            Stop gtfsStop = gtfsStopTimes.get(gtfsStopTimeIndex).getStop();
+                            Stop gtfsStop = (Stop) gtfsStopTimes.get(gtfsStopTimeIndex).getStop();
                             boolean foundStopSequence = false;
                             boolean foundStopId = false;
                             if (stopTimeUpdate.hasStopSequence()) {
                                 if (gtfsStopSequence == stopTimeUpdate.getStopSequence()) {
                                     // Found a matching stop_sequence from GTFS stop_times.txt
                                     checkE045(entity, tripUpdate, stopTimeUpdate, gtfsStopSequence, gtfsStop, e045List);
-                                    checkE046(entity, tripUpdate, stopTimeUpdate, gtfsStopTimes.get(gtfsStopTimeIndex), e046List);
+                                    checkE046(entity, tripUpdate, stopTimeUpdate, gtfsStopTimes.get(gtfsStopTimeIndex),
+                                            e046List);
                                     foundStopSequence = true;
                                 }
                             }
                             if (stopTimeUpdate.hasStopId()) {
                                 if (gtfsStop.getId().getId().equals(stopTimeUpdate.getStopId())) {
                                     /**
-                                     * Found a matching stop_id - note that there could be loops in routes, so unlike
-                                     * stop_sequence this isn't a definitive match between this stopTimeUpdate and a GTFS stop_times.txt entry
+                                     * Found a matching stop_id - note that there could be loops in routes, so
+                                     * unlike
+                                     * stop_sequence this isn't a definitive match between this stopTimeUpdate and a
+                                     * GTFS stop_times.txt entry
                                      */
                                     foundStopId = true;
                                 }
                             }
                             gtfsStopTimeIndex++;
                             if (foundStopSequence) {
-                                // We caught up with the stop_sequence in GTFS data - stop so we can pick up from here in next WHILE loop
+                                // We caught up with the stop_sequence in GTFS data - stop so we can pick up
+                                // from here in next WHILE loop
                                 break;
                             } else {
                                 if (stopTimeUpdate.hasStopSequence() && gtfsStopTimeIndex == gtfsStopTimes.size()) {
-                                    // For E051 - we've reached the last GTFS stop_times.txt record for the GTFS-rt stop_time_update and haven't found stop_sequence (#261)
+                                    // For E051 - we've reached the last GTFS stop_times.txt record for the GTFS-rt
+                                    // stop_time_update and haven't found stop_sequence (#261)
                                     unknownRtStopSequence = true;
                                 }
                                 if (!stopTimeUpdate.hasStopSequence() && foundStopId) {
-                                    // For E002 - in the case when stop_sequence is missing from the GTFS-rt feed, add the GTFS stop_sequence (See #159)
+                                    // For E002 - in the case when stop_sequence is missing from the GTFS-rt feed,
+                                    // add the GTFS stop_sequence (See #159)
                                     if (!stopTimeUpdate.hasStopSequence()) {
                                         rtStopSequenceList.add(gtfsStopSequence);
                                         addedStopSequenceFromStopId = true;
                                     }
 
                                     // E046 hasn't been checked yet if a stop_sequence doesn't exist - check now
-                                    checkE046(entity, tripUpdate, stopTimeUpdate, gtfsStopTimes.get(gtfsStopTimeIndex - 1), e046List);
-                                    // We caught up with a matching stop_id in GTFS data - stop so we can pick up from here in next WHILE loop
+                                    checkE046(entity, tripUpdate, stopTimeUpdate,
+                                            gtfsStopTimes.get(gtfsStopTimeIndex - 1), e046List);
+                                    // We caught up with a matching stop_id in GTFS data - stop so we can pick up
+                                    // from here in next WHILE loop
                                     // Note that for routes with loops, we could potentially be stopping prematurely
                                     break;
                                 }
@@ -172,10 +188,17 @@ public class StopTimeUpdateValidator implements FeedEntityValidator {
 
                     if (unknownRtStopSequence) {
                         // E051 - GTFS-rt stop_sequence not found in GTFS data
-                        RuleUtils.addOccurrence(ValidationRules.E051, "GTFS-rt " + GtfsUtils.getTripId(entity, tripUpdate) + " contains stop_sequence " + stopTimeUpdate.getStopSequence(), e051List, _log);
-                        // We couldn't find this stopTimeUpdate.stop_sequence in the GTFS stop_times.txt for this trip (E051). To keep validator running complexity
-                        // at O(n) for evaluating TripUpdates w/ GTFS stop_times.txt (i.e., don't loop through the entire GTFS stop_times.txt for each GTFS-rt stop_time_update, which would be O(n*m)), we
-                        // will skip validating the stop_time_updates for the rest of this trip.  When the producer fixes this erroneous stop_time_update.stop_sequence,
+                        RuleUtils.addOccurrence(
+                                ValidationRules.E051, "GTFS-rt " + GtfsUtils.getTripId(entity, tripUpdate)
+                                        + " contains stop_sequence " + stopTimeUpdate.getStopSequence(),
+                                e051List, _log);
+                        // We couldn't find this stopTimeUpdate.stop_sequence in the GTFS stop_times.txt
+                        // for this trip (E051). To keep validator running complexity
+                        // at O(n) for evaluating TripUpdates w/ GTFS stop_times.txt (i.e., don't loop
+                        // through the entire GTFS stop_times.txt for each GTFS-rt stop_time_update,
+                        // which would be O(n*m)), we
+                        // will skip validating the stop_time_updates for the rest of this trip. When
+                        // the producer fixes this erroneous stop_time_update.stop_sequence,
                         // the remaining stop_time_updates for this GTFS-rt trip will be validated.
                         break;
                     }
@@ -183,17 +206,22 @@ public class StopTimeUpdateValidator implements FeedEntityValidator {
 
                 boolean sorted = Ordering.natural().isStrictlyOrdered(rtStopSequenceList);
                 if (!sorted) {
-                    // E002 - stop_time_updates for a given trip_id must be sorted by increasing stop_sequence
+                    // E002 - stop_time_updates for a given trip_id must be sorted by increasing
+                    // stop_sequence
                     String id = GtfsUtils.getTripId(entity, tripUpdate);
-                    RuleUtils.addOccurrence(ValidationRules.E002, id + " stop_sequence " + rtStopSequenceList.toString(), e002List, _log);
+                    RuleUtils.addOccurrence(ValidationRules.E002,
+                            id + " stop_sequence " + rtStopSequenceList.toString(), e002List, _log);
                 } else if (addedStopSequenceFromStopId) {
                     // TripUpdate was missing at least one stop_sequence
                     if (rtStopSequenceList.size() < rtStopTimeUpdateList.size()) {
-                        // We didn't find all of the stop_time_updates in GTFS using stop_id, so stop_time_updates are
+                        // We didn't find all of the stop_time_updates in GTFS using stop_id, so
+                        // stop_time_updates are
                         // out of sequence
-                        // E002 - stop_time_updates for a given trip_id must be sorted by increasing stop_sequence
+                        // E002 - stop_time_updates for a given trip_id must be sorted by increasing
+                        // stop_sequence
                         String id = GtfsUtils.getTripId(entity, tripUpdate);
-                        RuleUtils.addOccurrence(ValidationRules.E002, id + " stop_sequence for stop_ids " + rtStopIdList.toString(), e002List, _log);
+                        RuleUtils.addOccurrence(ValidationRules.E002,
+                                id + " stop_sequence for stop_ids " + rtStopIdList.toString(), e002List, _log);
                     }
                 }
             }
@@ -240,7 +268,8 @@ public class StopTimeUpdateValidator implements FeedEntityValidator {
     }
 
     /**
-     * Checks E036 - if the provided previousStopSequence value is the same as the current stopTimeUpdate stop_sequence
+     * Checks E036 - if the provided previousStopSequence value is the same as the
+     * current stopTimeUpdate stop_sequence
      * it adds an error to the provided error list.
      *
      * @param entity               entity that the stopTimeUpdate is from
@@ -248,16 +277,19 @@ public class StopTimeUpdateValidator implements FeedEntityValidator {
      * @param stopTimeUpdate       the current stopTimeUpdate
      * @param errors               the list to add the errors to
      */
-    private void checkE036(GtfsRealtime.FeedEntity entity, Integer previousStopSequence, GtfsRealtime.TripUpdate.StopTimeUpdate stopTimeUpdate, List<OccurrenceModel> errors) {
+    private void checkE036(GtfsRealtime.FeedEntity entity, Integer previousStopSequence,
+            GtfsRealtime.TripUpdate.StopTimeUpdate stopTimeUpdate, List<OccurrenceModel> errors) {
         if (stopTimeUpdate.hasStopSequence() &&
                 previousStopSequence == stopTimeUpdate.getStopSequence()) {
             String id = GtfsUtils.getTripId(entity, entity.getTripUpdate());
-            RuleUtils.addOccurrence(ValidationRules.E036, id + " has repeating stop_sequence " + previousStopSequence, errors, _log);
+            RuleUtils.addOccurrence(ValidationRules.E036, id + " has repeating stop_sequence " + previousStopSequence,
+                    errors, _log);
         }
     }
 
     /**
-     * Checks E037 - if the provided previousStopId value is the same as the current stopTimeUpdate stop_id it adds
+     * Checks E037 - if the provided previousStopId value is the same as the current
+     * stopTimeUpdate stop_id it adds
      * an error to the provided error list.
      *
      * @param entity         entity that the stopTimeUpdate is from
@@ -265,7 +297,8 @@ public class StopTimeUpdateValidator implements FeedEntityValidator {
      * @param stopTimeUpdate the current stopTimeUpdate
      * @param errors         the list to add the errors to
      */
-    private void checkE037(GtfsRealtime.FeedEntity entity, String previousStopId, GtfsRealtime.TripUpdate.StopTimeUpdate stopTimeUpdate, List<OccurrenceModel> errors) {
+    private void checkE037(GtfsRealtime.FeedEntity entity, String previousStopId,
+            GtfsRealtime.TripUpdate.StopTimeUpdate stopTimeUpdate, List<OccurrenceModel> errors) {
         if (!previousStopId.isEmpty() && stopTimeUpdate.hasStopId() &&
                 previousStopId.equals(stopTimeUpdate.getStopId())) {
             String id = GtfsUtils.getTripId(entity, entity.getTripUpdate());
@@ -282,32 +315,38 @@ public class StopTimeUpdateValidator implements FeedEntityValidator {
     }
 
     /**
-     * Checks E040 "stop_time_update doesn't contain stop_id or stop_sequence", and adds any errors to the provided error list.
+     * Checks E040 "stop_time_update doesn't contain stop_id or stop_sequence", and
+     * adds any errors to the provided error list.
      *
      * @param entity         entity that the stopTimeUpdate is from
      * @param tripUpdate     the trip_update for the StopTimeUpdate
      * @param stopTimeUpdate the stop_time_update to check for E040
      * @param errors         the list to add the errors to
      */
-    private void checkE040(GtfsRealtime.FeedEntity entity, GtfsRealtime.TripUpdate tripUpdate, GtfsRealtime.TripUpdate.StopTimeUpdate stopTimeUpdate, List<OccurrenceModel> errors) {
+    private void checkE040(GtfsRealtime.FeedEntity entity, GtfsRealtime.TripUpdate tripUpdate,
+            GtfsRealtime.TripUpdate.StopTimeUpdate stopTimeUpdate, List<OccurrenceModel> errors) {
         if (!stopTimeUpdate.hasStopSequence() && !stopTimeUpdate.hasStopId()) {
             RuleUtils.addOccurrence(ValidationRules.E040, GtfsUtils.getTripId(entity, tripUpdate), errors, _log);
         }
     }
 
     /**
-     * Checks E041 "trip doesn't have any stop_time_updates", and adds any errors to the provided error list.
+     * Checks E041 "trip doesn't have any stop_time_updates", and adds any errors to
+     * the provided error list.
      *
      * @param entity     entity that the trip_update is from
      * @param tripUpdate the trip_update to examine
      * @param errors     the list to add the errors to
      */
-    private void checkE041(GtfsRealtime.FeedEntity entity, GtfsRealtime.TripUpdate tripUpdate, List<OccurrenceModel> errors) {
+    private void checkE041(GtfsRealtime.FeedEntity entity, GtfsRealtime.TripUpdate tripUpdate,
+            List<OccurrenceModel> errors) {
         if (tripUpdate.getStopTimeUpdateCount() < 1) {
             if (tripUpdate.hasTrip() &&
                     tripUpdate.getTrip().hasScheduleRelationship() &&
-                    tripUpdate.getTrip().getScheduleRelationship().equals(GtfsRealtime.TripDescriptor.ScheduleRelationship.CANCELED)) {
-                // No errors - the trip was canceled, so it doesn't need any stop_time_updates - return
+                    tripUpdate.getTrip().getScheduleRelationship()
+                            .equals(GtfsRealtime.TripDescriptor.ScheduleRelationship.CANCELED)) {
+                // No errors - the trip was canceled, so it doesn't need any stop_time_updates -
+                // return
                 return;
             }
             RuleUtils.addOccurrence(ValidationRules.E041, GtfsUtils.getTripId(entity, tripUpdate), errors, _log);
@@ -315,14 +354,16 @@ public class StopTimeUpdateValidator implements FeedEntityValidator {
     }
 
     /**
-     * Checks E042 "arrival or departure provided for NO_DATA stop_time_update", and adds any errors to the provided error list.
+     * Checks E042 "arrival or departure provided for NO_DATA stop_time_update", and
+     * adds any errors to the provided error list.
      *
      * @param entity         entity that the trip_update is from
      * @param tripUpdate     the trip_update to examine
      * @param stopTimeUpdate the stop_time_update to examine
      * @param errors         the list to add the errors to
      */
-    private void checkE042(GtfsRealtime.FeedEntity entity, GtfsRealtime.TripUpdate tripUpdate, GtfsRealtime.TripUpdate.StopTimeUpdate stopTimeUpdate, List<OccurrenceModel> errors) {
+    private void checkE042(GtfsRealtime.FeedEntity entity, GtfsRealtime.TripUpdate tripUpdate,
+            GtfsRealtime.TripUpdate.StopTimeUpdate stopTimeUpdate, List<OccurrenceModel> errors) {
         if (stopTimeUpdate.hasScheduleRelationship() &&
                 stopTimeUpdate.getScheduleRelationship().equals(NO_DATA)) {
             String id = GtfsUtils.getTripId(entity, tripUpdate) + " " + GtfsUtils.getStopTimeUpdateId(stopTimeUpdate);
@@ -337,19 +378,22 @@ public class StopTimeUpdateValidator implements FeedEntityValidator {
     }
 
     /**
-     * Checks E043 "stop_time_update doesn't have arrival or departure", and adds any errors to the provided error list.
+     * Checks E043 "stop_time_update doesn't have arrival or departure", and adds
+     * any errors to the provided error list.
      *
      * @param entity         entity that the trip_update is from
      * @param tripUpdate     the trip_update to examine
      * @param stopTimeUpdate the stop_time_update to examine
      * @param errors         the list to add the errors to
      */
-    private void checkE043(GtfsRealtime.FeedEntity entity, GtfsRealtime.TripUpdate tripUpdate, GtfsRealtime.TripUpdate.StopTimeUpdate stopTimeUpdate, List<OccurrenceModel> errors) {
+    private void checkE043(GtfsRealtime.FeedEntity entity, GtfsRealtime.TripUpdate tripUpdate,
+            GtfsRealtime.TripUpdate.StopTimeUpdate stopTimeUpdate, List<OccurrenceModel> errors) {
         if (!stopTimeUpdate.hasArrival() && !stopTimeUpdate.hasDeparture()) {
             if (stopTimeUpdate.hasScheduleRelationship() &&
                     (stopTimeUpdate.getScheduleRelationship().equals(SKIPPED) ||
                             stopTimeUpdate.getScheduleRelationship().equals(NO_DATA))) {
-                // stop_time_updates with SKIPPED or NO_DATA aren't required to have arrival or departures - return
+                // stop_time_updates with SKIPPED or NO_DATA aren't required to have arrival or
+                // departures - return
                 return;
             }
             String id = GtfsUtils.getTripId(entity, tripUpdate) + " " + GtfsUtils.getStopTimeUpdateId(stopTimeUpdate);
@@ -358,16 +402,19 @@ public class StopTimeUpdateValidator implements FeedEntityValidator {
     }
 
     /**
-     * Checks E044 "stop_time_update arrival/departure doesn't have delay or time", and adds any errors to the provided error list.
+     * Checks E044 "stop_time_update arrival/departure doesn't have delay or time",
+     * and adds any errors to the provided error list.
      *
      * @param entity         entity that the trip_update is from
      * @param tripUpdate     the trip_update to examine
      * @param stopTimeUpdate the stop_time_update to examine
      * @param errors         the list to add the errors to
      */
-    private void checkE044(GtfsRealtime.FeedEntity entity, GtfsRealtime.TripUpdate tripUpdate, GtfsRealtime.TripUpdate.StopTimeUpdate stopTimeUpdate, List<OccurrenceModel> errors) {
+    private void checkE044(GtfsRealtime.FeedEntity entity, GtfsRealtime.TripUpdate tripUpdate,
+            GtfsRealtime.TripUpdate.StopTimeUpdate stopTimeUpdate, List<OccurrenceModel> errors) {
         if (stopTimeUpdate.hasScheduleRelationship() && stopTimeUpdate.getScheduleRelationship().equals(SKIPPED)) {
-            // SKIPPED stop_time_updates aren't required to have delay or time (arrival/departure are optional) - see #243
+            // SKIPPED stop_time_updates aren't required to have delay or time
+            // (arrival/departure are optional) - see #243
             return;
         }
         String id = GtfsUtils.getTripId(entity, tripUpdate) + " " + GtfsUtils.getStopTimeUpdateId(stopTimeUpdate);
@@ -380,48 +427,61 @@ public class StopTimeUpdateValidator implements FeedEntityValidator {
     }
 
     /**
-     * Checks StopTimeEvent for rule E044 - "stop_time_update arrival/departure doesn't have delay or time" and adds any errors to the provided errors list
+     * Checks StopTimeEvent for rule E044 - "stop_time_update arrival/departure
+     * doesn't have delay or time" and adds any errors to the provided errors list
      *
      * @param stopTimeEvent    the arrival or departure to examine
      * @param occurrencePrefix prefix to use for the OccurrenceModel constructor
      * @param errors           list to add occurrence for E044 to
      */
-    private void checkE044StopTimeEvent(GtfsRealtime.TripUpdate.StopTimeEvent stopTimeEvent, String occurrencePrefix, List<OccurrenceModel> errors) {
+    private void checkE044StopTimeEvent(GtfsRealtime.TripUpdate.StopTimeEvent stopTimeEvent, String occurrencePrefix,
+            List<OccurrenceModel> errors) {
         if (!stopTimeEvent.hasDelay() && !stopTimeEvent.hasTime()) {
             RuleUtils.addOccurrence(ValidationRules.E044, occurrencePrefix, errors, _log);
         }
     }
 
     /**
-     * Checks E045 "GTFS-rt stop_time_update stop_sequence and stop_id do not match GTFS", and adds any errors to the provided error list.
+     * Checks E045 "GTFS-rt stop_time_update stop_sequence and stop_id do not match
+     * GTFS", and adds any errors to the provided error list.
      *
      * @param entity           entity that the trip_update is from
      * @param tripUpdate       the trip_update to examine
      * @param stopTimeUpdate   the stop_time_update to examine
      * @param gtfsStopSequence the stop_sequence from the GTFS stop_times.txt data
-     * @param stop             the GTFS stop that is paired with the provided gtfsStopSequence, using stop_id from the same record in stop_times.txt
+     * @param stop             the GTFS stop that is paired with the provided
+     *                         gtfsStopSequence, using stop_id from the same record
+     *                         in stop_times.txt
      * @param errors           the list to add the errors to
      */
-    private void checkE045(GtfsRealtime.FeedEntity entity, GtfsRealtime.TripUpdate tripUpdate, GtfsRealtime.TripUpdate.StopTimeUpdate stopTimeUpdate, int gtfsStopSequence, Stop stop, List<OccurrenceModel> errors) {
+    private void checkE045(GtfsRealtime.FeedEntity entity, GtfsRealtime.TripUpdate tripUpdate,
+            GtfsRealtime.TripUpdate.StopTimeUpdate stopTimeUpdate, int gtfsStopSequence, Stop stop,
+            List<OccurrenceModel> errors) {
         if (stopTimeUpdate.hasStopId() && !stop.getId().getId().equals(stopTimeUpdate.getStopId())) {
             String tripId = "GTFS-rt " + GtfsUtils.getTripId(entity, tripUpdate) + " ";
             String stopSequence = "stop_sequence " + stopTimeUpdate.getStopSequence();
             String stopId = "stop_id " + stopTimeUpdate.getStopId();
             String gtfsSummary = " but GTFS stop_sequence " + gtfsStopSequence + " has stop_id " + stop.getId().getId();
-            RuleUtils.addOccurrence(ValidationRules.E045, tripId + stopSequence + " has " + stopId + gtfsSummary, errors, _log);
+            RuleUtils.addOccurrence(ValidationRules.E045, tripId + stopSequence + " has " + stopId + gtfsSummary,
+                    errors, _log);
         }
     }
 
     /**
-     * Checks E046 "GTFS-rt stop_time_update without time doesn't have arrival/departure_time in GTFS", and adds any errors to the provided error list.
+     * Checks E046 "GTFS-rt stop_time_update without time doesn't have
+     * arrival/departure_time in GTFS", and adds any errors to the provided error
+     * list.
      *
      * @param entity         entity that the trip_update is from
      * @param tripUpdate     the trip_update to examine
      * @param stopTimeUpdate the stop_time_update to examine
-     * @param gtfsStopTime   the entry from GTFS stop_times.txt that corresponds to the provided GTFS stopTimeUpdate
+     * @param gtfsStopTime   the entry from GTFS stop_times.txt that corresponds to
+     *                       the provided GTFS stopTimeUpdate
      * @param errors         the list to add the errors to
      */
-    private void checkE046(GtfsRealtime.FeedEntity entity, GtfsRealtime.TripUpdate tripUpdate, GtfsRealtime.TripUpdate.StopTimeUpdate stopTimeUpdate, StopTime gtfsStopTime, List<OccurrenceModel> errors) {
+    private void checkE046(GtfsRealtime.FeedEntity entity, GtfsRealtime.TripUpdate tripUpdate,
+            GtfsRealtime.TripUpdate.StopTimeUpdate stopTimeUpdate, StopTime gtfsStopTime,
+            List<OccurrenceModel> errors) {
         StringBuilder prefixBuilder = new StringBuilder();
         prefixBuilder.append("GTFS-rt " + GtfsUtils.getTripId(entity, tripUpdate) + " ");
         prefixBuilder.append(GtfsUtils.getStopTimeUpdateId(stopTimeUpdate) + " ");

--- a/pom.xml
+++ b/pom.xml
@@ -32,7 +32,7 @@
         </repository>
         <repository>
             <id>public.onebusaway.org</id>
-            <url>https://repo.camsys-apps.com/releases/</url>
+            <url>https://central.sonatype.com/namespace/org.onebusaway</url>
         </repository>
     </repositories>
     <distributionManagement>


### PR DESCRIPTION
**Summary:**

Closes https://github.com/MobilityData/gtfs-realtime-validator/issues/92

**Problem**

When a GTFS static feed includes the optional `areas.txt` file from the GTFS Facilities, the realtime validator lib will crash if the `areas.txt` file does not contain a `wkt` field. The `wkt` field is [no longer in the GTFS static specification](https://github.com/google/transit/blame/1540c87c52b4f10ed88861d5b7e154afbfa97f2a/gtfs/spec/en/reference.md#L577)

**Expected behavior:** 

The validator should not choke on a GTFS static schedule with an `areas.txt` file included. This w[as already fixed upstream in the `onebus-gtfs` dependency,](https://github.com/OneBusAway/onebusaway-gtfs-modules/commit/bf90a7a29b54deba49428adbd313ee875455e65d) so I upgraded the dependency to the newest version with this fix included.

