### PR TITLE
Add gtfs-realtime-validator-api: thin REST wrapper around the lib

### DIFF
--- a/gtfs-realtime-validator-api/pom.xml
+++ b/gtfs-realtime-validator-api/pom.xml
@@ -1,0 +1,99 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.mobilitydata</groupId>
+        <artifactId>gtfs-realtime-validator</artifactId>
+        <version>1.0.0-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>gtfs-realtime-validator-api</artifactId>
+    <version>1.0.0-SNAPSHOT</version>
+    <packaging>jar</packaging>
+
+    <properties>
+        <maven.compiler.source>11</maven.compiler.source>
+        <maven.compiler.target>11</maven.compiler.target>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.mobilitydata</groupId>
+            <artifactId>gtfs-realtime-validator-lib</artifactId>
+            <version>1.0.0-SNAPSHOT</version>
+        </dependency>
+
+        <dependency>
+            <groupId>io.javalin</groupId>
+            <artifactId>javalin</artifactId>
+            <version>5.6.5</version>
+        </dependency>
+
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+            <version>2.13.2.1</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-simple</artifactId>
+            <version>1.7.25</version>
+            <scope>runtime</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.11.0</version>
+                <configuration>
+                    <source>11</source>
+                    <target>11</target>
+                </configuration>
+            </plugin>
+
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-shade-plugin</artifactId>
+                <version>3.5.1</version>
+                <configuration>
+                    <createDependencyReducedPom>false</createDependencyReducedPom>
+                    <filters>
+                        <filter>
+                            <artifact>*:*</artifact>
+                            <excludes>
+                                <exclude>META-INF/*.SF</exclude>
+                                <exclude>META-INF/*.DSA</exclude>
+                                <exclude>META-INF/*.RSA</exclude>
+                            </excludes>
+                        </filter>
+                    </filters>
+                    <shadedClassifierName>withAllDependencies</shadedClassifierName>
+                    <transformers>
+                        <transformer
+                                implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
+                            <mainClass>edu.usf.cutr.gtfsrtvalidator.restapi.Main</mainClass>
+                        </transformer>
+                        <transformer
+                                implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer"/>
+                    </transformers>
+                </configuration>
+                <executions>
+                    <execution>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>shade</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/gtfs-realtime-validator-api/src/main/java/edu/usf/cutr/gtfsrtvalidator/restapi/Main.java
+++ b/gtfs-realtime-validator-api/src/main/java/edu/usf/cutr/gtfsrtvalidator/restapi/Main.java
@@ -1,0 +1,88 @@
+package edu.usf.cutr.gtfsrtvalidator.restapi;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import io.javalin.Javalin;
+import io.javalin.json.JavalinJackson;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+
+public class Main {
+
+    private static final Logger log = LoggerFactory.getLogger(Main.class);
+
+    public static void main(String[] args) {
+        int port = resolvePort();
+        List<String> corsOrigins = resolveCorsOrigins();
+        ValidationService service = new ValidationService();
+
+        ObjectMapper mapper = new ObjectMapper();
+        mapper.configure(SerializationFeature.FAIL_ON_EMPTY_BEANS, false);
+
+        Javalin app = Javalin.create(config -> {
+            config.jsonMapper(new JavalinJackson(mapper));
+            config.plugins.enableCors(cors -> cors.add(it -> {
+                if (corsOrigins.isEmpty()) {
+                    it.anyHost();
+                } else {
+                    it.allowHost(corsOrigins.get(0), corsOrigins.subList(1, corsOrigins.size()).toArray(new String[0]));
+                }
+            }));
+        });
+
+        app.get("/health", ctx -> ctx.json(Map.of("status", "ok")));
+
+        app.post("/api/validate", ctx -> {
+            ValidateRequest req = ctx.bodyAsClass(ValidateRequest.class);
+            try {
+                ValidationResponse response = service.validate(req.gtfsUrl, req.gtfsRtUrl);
+                ctx.json(response);
+            } catch (ValidationException e) {
+                ctx.status(e.getStatus()).json(Map.of("error", e.getMessage()));
+            } catch (Exception e) {
+                log.error("Unexpected error during validation", e);
+                ctx.status(500).json(Map.of("error", "Internal server error"));
+            }
+        });
+
+        app.start(port);
+        log.info("gtfs-realtime-validator-api listening on http://localhost:{}", port);
+        if (corsOrigins.isEmpty()) {
+            log.info("CORS: any host (set CORS_ALLOWED_ORIGINS to restrict)");
+        } else {
+            log.info("CORS: allowed origins = {}", corsOrigins);
+        }
+    }
+
+    private static int resolvePort() {
+        String env = System.getenv("PORT");
+        if (env != null && !env.isBlank()) {
+            try {
+                return Integer.parseInt(env.trim());
+            } catch (NumberFormatException e) {
+                log.warn("Invalid PORT env value '{}', falling back to default", env);
+            }
+        }
+        return 8090;
+    }
+
+    private static List<String> resolveCorsOrigins() {
+        String env = System.getenv("CORS_ALLOWED_ORIGINS");
+        if (env == null || env.isBlank()) {
+            return List.of();
+        }
+        return Arrays.stream(env.split(","))
+                .map(String::trim)
+                .filter(s -> !s.isEmpty())
+                .toList();
+    }
+
+    public static class ValidateRequest {
+        public String gtfsUrl;
+        public String gtfsRtUrl;
+    }
+}

--- a/gtfs-realtime-validator-api/src/main/java/edu/usf/cutr/gtfsrtvalidator/restapi/SkippedRule.java
+++ b/gtfs-realtime-validator-api/src/main/java/edu/usf/cutr/gtfsrtvalidator/restapi/SkippedRule.java
@@ -1,0 +1,18 @@
+package edu.usf.cutr.gtfsrtvalidator.restapi;
+
+public class SkippedRule {
+
+    private final String name;
+    private final String exceptionClass;
+    private final String message;
+
+    public SkippedRule(String name, String exceptionClass, String message) {
+        this.name = name;
+        this.exceptionClass = exceptionClass;
+        this.message = message;
+    }
+
+    public String getName() { return name; }
+    public String getExceptionClass() { return exceptionClass; }
+    public String getMessage() { return message; }
+}

--- a/gtfs-realtime-validator-api/src/main/java/edu/usf/cutr/gtfsrtvalidator/restapi/ValidationError.java
+++ b/gtfs-realtime-validator-api/src/main/java/edu/usf/cutr/gtfsrtvalidator/restapi/ValidationError.java
@@ -1,0 +1,57 @@
+package edu.usf.cutr.gtfsrtvalidator.restapi;
+
+import edu.usf.cutr.gtfsrtvalidator.lib.model.OccurrenceModel;
+import edu.usf.cutr.gtfsrtvalidator.lib.model.ValidationRule;
+import edu.usf.cutr.gtfsrtvalidator.lib.model.helper.ErrorListHelperModel;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+public class ValidationError {
+
+    private final String errorId;
+    private final String severity;
+    private final String title;
+    private final String description;
+    private final String suffix;
+    private final String errorDetails;
+    private final List<String> occurrences;
+
+    public ValidationError(String errorId, String severity, String title, String description,
+                           String suffix, String errorDetails, List<String> occurrences) {
+        this.errorId = errorId;
+        this.severity = severity;
+        this.title = title;
+        this.description = description;
+        this.suffix = suffix;
+        this.errorDetails = errorDetails;
+        this.occurrences = List.copyOf(occurrences);
+    }
+
+    public static ValidationError from(ErrorListHelperModel model) {
+        ValidationRule rule = model.getErrorMessage() != null ? model.getErrorMessage().getValidationRule() : null;
+        String errorDetails = model.getErrorMessage() != null ? model.getErrorMessage().getErrorDetails() : null;
+        List<String> occurrences = model.getOccurrenceList() == null
+                ? List.of()
+                : model.getOccurrenceList().stream()
+                        .map(OccurrenceModel::getPrefix)
+                        .collect(Collectors.toUnmodifiableList());
+        return new ValidationError(
+                rule != null ? rule.getErrorId() : null,
+                rule != null ? rule.getSeverity() : null,
+                rule != null ? rule.getTitle() : null,
+                rule != null ? rule.getErrorDescription() : null,
+                rule != null ? rule.getOccurrenceSuffix() : null,
+                errorDetails,
+                occurrences
+        );
+    }
+
+    public String getErrorId() { return errorId; }
+    public String getSeverity() { return severity; }
+    public String getTitle() { return title; }
+    public String getDescription() { return description; }
+    public String getSuffix() { return suffix; }
+    public String getErrorDetails() { return errorDetails; }
+    public List<String> getOccurrences() { return occurrences; }
+}

--- a/gtfs-realtime-validator-api/src/main/java/edu/usf/cutr/gtfsrtvalidator/restapi/ValidationException.java
+++ b/gtfs-realtime-validator-api/src/main/java/edu/usf/cutr/gtfsrtvalidator/restapi/ValidationException.java
@@ -1,0 +1,24 @@
+package edu.usf.cutr.gtfsrtvalidator.restapi;
+
+import io.javalin.http.HttpStatus;
+
+import java.util.Objects;
+
+public class ValidationException extends Exception {
+
+    private final HttpStatus status;
+
+    public ValidationException(HttpStatus status, String message) {
+        super(message);
+        this.status = Objects.requireNonNull(status);
+    }
+
+    public ValidationException(HttpStatus status, String message, Throwable cause) {
+        super(message, cause);
+        this.status = Objects.requireNonNull(status);
+    }
+
+    public HttpStatus getStatus() {
+        return status;
+    }
+}

--- a/gtfs-realtime-validator-api/src/main/java/edu/usf/cutr/gtfsrtvalidator/restapi/ValidationResponse.java
+++ b/gtfs-realtime-validator-api/src/main/java/edu/usf/cutr/gtfsrtvalidator/restapi/ValidationResponse.java
@@ -1,0 +1,31 @@
+package edu.usf.cutr.gtfsrtvalidator.restapi;
+
+import java.util.List;
+
+public class ValidationResponse {
+
+    private final String gtfsUrl;
+    private final String gtfsRtUrl;
+    private final long currentTimeMillis;
+    private final long feedTimestampSeconds;
+    private final List<ValidationError> results;
+    private final List<SkippedRule> skippedRules;
+
+    public ValidationResponse(String gtfsUrl, String gtfsRtUrl, long currentTimeMillis,
+                              long feedTimestampSeconds, List<ValidationError> results,
+                              List<SkippedRule> skippedRules) {
+        this.gtfsUrl = gtfsUrl;
+        this.gtfsRtUrl = gtfsRtUrl;
+        this.currentTimeMillis = currentTimeMillis;
+        this.feedTimestampSeconds = feedTimestampSeconds;
+        this.results = List.copyOf(results);
+        this.skippedRules = List.copyOf(skippedRules);
+    }
+
+    public String getGtfsUrl() { return gtfsUrl; }
+    public String getGtfsRtUrl() { return gtfsRtUrl; }
+    public long getCurrentTimeMillis() { return currentTimeMillis; }
+    public long getFeedTimestampSeconds() { return feedTimestampSeconds; }
+    public List<ValidationError> getResults() { return results; }
+    public List<SkippedRule> getSkippedRules() { return skippedRules; }
+}

--- a/gtfs-realtime-validator-api/src/main/java/edu/usf/cutr/gtfsrtvalidator/restapi/ValidationService.java
+++ b/gtfs-realtime-validator-api/src/main/java/edu/usf/cutr/gtfsrtvalidator/restapi/ValidationService.java
@@ -1,0 +1,214 @@
+package edu.usf.cutr.gtfsrtvalidator.restapi;
+
+import com.google.transit.realtime.GtfsRealtime;
+import edu.usf.cutr.gtfsrtvalidator.lib.model.helper.ErrorListHelperModel;
+import edu.usf.cutr.gtfsrtvalidator.lib.util.GtfsUtils;
+import edu.usf.cutr.gtfsrtvalidator.lib.validation.GtfsMetadata;
+import edu.usf.cutr.gtfsrtvalidator.lib.validation.interfaces.FeedEntityValidator;
+import edu.usf.cutr.gtfsrtvalidator.lib.validation.rules.CrossFeedDescriptorValidator;
+import edu.usf.cutr.gtfsrtvalidator.lib.validation.rules.FrequencyTypeOneValidator;
+import edu.usf.cutr.gtfsrtvalidator.lib.validation.rules.FrequencyTypeZeroValidator;
+import edu.usf.cutr.gtfsrtvalidator.lib.validation.rules.HeaderValidator;
+import edu.usf.cutr.gtfsrtvalidator.lib.validation.rules.StopTimeUpdateValidator;
+import edu.usf.cutr.gtfsrtvalidator.lib.validation.rules.StopValidator;
+import edu.usf.cutr.gtfsrtvalidator.lib.validation.rules.TimestampValidator;
+import edu.usf.cutr.gtfsrtvalidator.lib.validation.rules.TripDescriptorValidator;
+import edu.usf.cutr.gtfsrtvalidator.lib.validation.rules.VehicleValidator;
+import io.javalin.http.HttpStatus;
+import org.onebusaway.gtfs.impl.GtfsDaoImpl;
+import org.onebusaway.gtfs.model.Agency;
+import org.onebusaway.gtfs.serialization.GtfsReader;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.HttpURLConnection;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.net.URL;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardCopyOption;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.TimeZone;
+
+public class ValidationService {
+
+    private static final Logger log = LoggerFactory.getLogger(ValidationService.class);
+
+    private static final int CONNECT_TIMEOUT_MS = 30_000;
+    private static final int READ_TIMEOUT_MS = 60_000;
+
+    private final List<FeedEntityValidator> validators;
+
+    public ValidationService() {
+        this.validators = List.of(
+                new CrossFeedDescriptorValidator(),
+                new VehicleValidator(),
+                new TimestampValidator(),
+                new StopTimeUpdateValidator(),
+                new TripDescriptorValidator(),
+                new StopValidator(),
+                new FrequencyTypeZeroValidator(),
+                new FrequencyTypeOneValidator(),
+                new HeaderValidator()
+        );
+    }
+
+    public ValidationResponse validate(String gtfsUrl, String gtfsRtUrl) throws ValidationException {
+        requireHttpUrl(gtfsUrl, "gtfsUrl");
+        requireHttpUrl(gtfsRtUrl, "gtfsRtUrl");
+
+        Path gtfsTempFile = null;
+        try {
+            gtfsTempFile = downloadToTempFile(gtfsUrl);
+
+            GtfsDaoImpl gtfsData = new GtfsDaoImpl();
+            GtfsReader reader = new GtfsReader();
+            try {
+                reader.setInputLocation(gtfsTempFile.toFile());
+                reader.setEntityStore(gtfsData);
+                reader.run();
+            } catch (IOException | RuntimeException e) {
+                throw new ValidationException(HttpStatus.UNPROCESSABLE_CONTENT, "Failed to parse GTFS zip: " + e.getMessage(), e);
+            }
+
+            String agencyTimezone = firstAgencyTimezone(gtfsData.getAllAgencies());
+            if (agencyTimezone == null) {
+                throw new ValidationException(HttpStatus.UNPROCESSABLE_CONTENT, "GTFS feed has no agencies with a timezone");
+            }
+
+            GtfsMetadata gtfsMetadata = new GtfsMetadata(
+                    gtfsTempFile.toAbsolutePath().toString(),
+                    TimeZone.getTimeZone(agencyTimezone),
+                    gtfsData,
+                    false
+            );
+
+            byte[] gtfsRtBytes = downloadBytes(gtfsRtUrl);
+            GtfsRealtime.FeedMessage feedMessage;
+            try {
+                feedMessage = GtfsRealtime.FeedMessage.parseFrom(gtfsRtBytes);
+            } catch (IOException e) {
+                throw new ValidationException(HttpStatus.UNPROCESSABLE_CONTENT, "Failed to parse GTFS-realtime protobuf: " + e.getMessage(), e);
+            }
+
+            GtfsRealtime.FeedMessage combinedFeed = GtfsUtils.isCombinedFeed(feedMessage) ? feedMessage : null;
+
+            long currentTimeMillis = System.currentTimeMillis();
+            long feedTimestampSeconds = feedMessage.hasHeader() ? feedMessage.getHeader().getTimestamp() : 0L;
+
+            List<ValidationError> results = new ArrayList<>();
+            List<SkippedRule> skippedRules = new ArrayList<>();
+            for (FeedEntityValidator rule : validators) {
+                String name = rule.getClass().getSimpleName();
+                try {
+                    List<ErrorListHelperModel> ruleResults = rule.validate(
+                            currentTimeMillis, gtfsData, gtfsMetadata, feedMessage, null, combinedFeed);
+                    if (ruleResults != null) {
+                        ruleResults.stream().map(ValidationError::from).forEach(results::add);
+                    }
+                } catch (Exception e) {
+                    skippedRules.add(new SkippedRule(name, e.getClass().getName(), e.getMessage()));
+                    log.error("Rule {} threw {}", name, e.getClass().getSimpleName(), e);
+                }
+            }
+
+            return new ValidationResponse(gtfsUrl, gtfsRtUrl, currentTimeMillis, feedTimestampSeconds, results, skippedRules);
+        } finally {
+            if (gtfsTempFile != null) {
+                try {
+                    Files.deleteIfExists(gtfsTempFile);
+                } catch (IOException e) {
+                    log.debug("Could not delete temp file {}: {}", gtfsTempFile, e.getMessage());
+                }
+            }
+        }
+    }
+
+    private static void requireHttpUrl(String value, String field) throws ValidationException {
+        if (value == null || value.isBlank()) {
+            throw new ValidationException(HttpStatus.BAD_REQUEST, field + " is required");
+        }
+        URI uri;
+        try {
+            uri = new URI(value).parseServerAuthority();
+        } catch (URISyntaxException | IllegalArgumentException e) {
+            throw new ValidationException(HttpStatus.BAD_REQUEST, field + " is not a valid URL");
+        }
+        String scheme = uri.getScheme();
+        if (scheme == null || !(scheme.equalsIgnoreCase("http") || scheme.equalsIgnoreCase("https"))) {
+            throw new ValidationException(HttpStatus.BAD_REQUEST, field + " must be an http or https URL");
+        }
+        if (uri.getHost() == null) {
+            throw new ValidationException(HttpStatus.BAD_REQUEST, field + " must include a host");
+        }
+    }
+
+    private static Path downloadToTempFile(String url) throws ValidationException {
+        Path file;
+        try {
+            file = Files.createTempFile("gtfs-", ".zip");
+        } catch (IOException e) {
+            throw new ValidationException(HttpStatus.INTERNAL_SERVER_ERROR, "Could not create temp file: " + e.getMessage(), e);
+        }
+        // Best-effort cleanup if the JVM exits before the finally block runs.
+        file.toFile().deleteOnExit();
+        try {
+            withConnection(url, in -> {
+                Files.copy(in, file, StandardCopyOption.REPLACE_EXISTING);
+                return null;
+            });
+            return file;
+        } catch (ValidationException e) {
+            try { Files.deleteIfExists(file); } catch (IOException ignored) { /* best effort */ }
+            throw e;
+        }
+    }
+
+    private static byte[] downloadBytes(String url) throws ValidationException {
+        return withConnection(url, InputStream::readAllBytes);
+    }
+
+    @FunctionalInterface
+    private interface IOFunction<T, R> {
+        R apply(T input) throws IOException;
+    }
+
+    private static <T> T withConnection(String url, IOFunction<InputStream, T> consumer) throws ValidationException {
+        HttpURLConnection conn = openConnection(url);
+        try (InputStream in = conn.getInputStream()) {
+            return consumer.apply(in);
+        } catch (IOException e) {
+            throw new ValidationException(HttpStatus.BAD_GATEWAY, "Failed to download " + url + ": " + e.getMessage(), e);
+        } finally {
+            conn.disconnect();
+        }
+    }
+
+    private static HttpURLConnection openConnection(String url) throws ValidationException {
+        try {
+            URL parsed = new URI(url).toURL();
+            HttpURLConnection conn = (HttpURLConnection) parsed.openConnection();
+            conn.setConnectTimeout(CONNECT_TIMEOUT_MS);
+            conn.setReadTimeout(READ_TIMEOUT_MS);
+            conn.setInstanceFollowRedirects(true);
+            conn.setRequestProperty("User-Agent", "gtfs-realtime-validator-api");
+            return conn;
+        } catch (IOException | URISyntaxException | IllegalArgumentException e) {
+            throw new ValidationException(HttpStatus.BAD_GATEWAY, "Could not open connection to " + url + ": " + e.getMessage(), e);
+        }
+    }
+
+    private static String firstAgencyTimezone(Collection<Agency> agencies) {
+        for (Agency a : agencies) {
+            if (a.getTimezone() != null && !a.getTimezone().isBlank()) {
+                return a.getTimezone();
+            }
+        }
+        return null;
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -16,6 +16,7 @@
     <modules>
         <module>gtfs-realtime-validator-lib</module>
 		<module>gtfs-realtime-validator-webapp</module>
+		<module>gtfs-realtime-validator-api</module>
     </modules>
 
     <repositories>


### PR DESCRIPTION
## Summary

- New Maven module `gtfs-realtime-validator-api/` exposing `POST /api/validate { gtfsUrl, gtfsRtUrl }` as a stateless one-shot validator. Reuses the existing 9 validator classes from `gtfs-realtime-validator-lib` (the same set used by `BackgroundTask`).
- Built on Javalin 5; no DB, no background polling, no Hibernate. Fat-jar via the shade plugin (mirrors the webapp's packaging).
- Intended as the backend for a forthcoming React UI to replace the current Jersey/Hibernate webapp's UX. This PR adds the API only; the UI is a separate change.

**Endpoints:**
- `GET /health` — `{"status":"ok"}`
- `POST /api/validate` — body `{ "gtfsUrl": "...", "gtfsRtUrl": "..." }` → `ValidationResponse` with `results` (list of `ValidationError`) and `skippedRules` (per-rule failures surface as 200 with the failing rule name + exception class/message rather than failing the whole request).

**Status code mapping:**
- `200` — success (may include non-empty `skippedRules`)
- `400` — missing field, non-`http(s)` scheme, missing host, malformed URL
- `422` — unparseable GTFS zip, unparseable GTFS-rt protobuf, GTFS missing agency timezone
- `502` — upstream fetch failure
- `500` — anything else (logged server-side; generic message returned)

**Config:**
- `PORT` (default `8090`) — chosen to avoid clashing with the existing webapp on 8080
- `CORS_ALLOWED_ORIGINS` (comma-separated; unset → any host)

## Test plan

- [x] `mvn package -pl gtfs-realtime-validator-api -am -DskipTests` builds cleanly
- [x] `GET /health` returns 200
- [x] Golden path: `POST /api/validate` against `bullrunner-gtfs.zip` + `bullrunner-vehicle-positions` (served via local HTTP) returns 200 with W001/W006/W008/W009 results, 31 occurrences, response shape `{ gtfsUrl, gtfsRtUrl, currentTimeMillis, feedTimestampSeconds, results, skippedRules }`
- [x] 400: empty `gtfsUrl`, `file://` scheme, malformed URL with whitespace, scheme-only URL with no host
- [x] 422: GTFS zip served as protobuf (unparseable PB), zip with no agencies/timezone path
- [x] 502: unreachable host

## Review notes (known follow-ups, not blocking this PR)

These came out of an internal review pass; surfacing for visibility:

- **SSRF guard.** The endpoint accepts arbitrary `http(s)` URLs from clients and the server fetches them, with `setInstanceFollowRedirects(true)`. No host allow-list, no private/loopback/link-local/cloud-metadata block. Same gap exists in the existing `BackgroundTask`/Jersey resources, so this is parity, not a regression — but worth a dedicated PR (DNS resolution + post-redirect re-validation).
- **Download size cap.** No upper bound on GTFS zip size (`Files.copy` streams to a temp file). Pairs with SSRF — together they're the DoS surface.
- **Non-2xx upstream HTTP responses currently collapse to 502.** A 404 on the GTFS URL surfaces as `BAD_GATEWAY "Failed to download …"`. Reading `getResponseCode()` first and mapping 4xx → 422 (caller-data problem) vs 5xx → 502 (upstream problem) would be more honest.
- **Request ID in 500 responses.** The catch-all logs the full stack but returns a generic message. A short request ID echoed in both the response and the log line would make production debugging easier.
- **Validator-list duplication.** `BatchProcessor`, `BackgroundTask`, and now `ValidationService` each declare the same 9 validators inline. Extracting a `Validators.defaultRules()` factory in the lib would consolidate these — out of scope here but worth a follow-up.
- **Test coverage.** No tests in this module yet. Minimum viable set worth landing: parameterized unit tests for `requireHttpUrl` (pure, no I/O) and an end-to-end happy-path integration test using the lib's existing `bullrunner-gtfs.zip` + `bullrunner-vehicle-positions` fixtures served via `com.sun.net.httpserver.HttpServer`. Will follow in a separate PR.
- **`jackson-databind` 2.13.2.1.** Matches the lib module's version (chosen for consistency) but has known CVEs. A coordinated bump across both modules to 2.17.x is worth doing.

## Notes on packaging

- Java 11 source/target (Javalin 5 requires 11+); the lib stays on Java 1.8.
- `<createDependencyReducedPom>false</createDependencyReducedPom>` to match the webapp's shade configuration and avoid a stray `dependency-reduced-pom.xml`.
- `slf4j-simple` declared at `runtime` scope so it doesn't leak as a compile-time dependency on consumers.